### PR TITLE
docs: add SandBase CLI to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 - 🌎 [Hexabot](hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
 - <b><code>&nbsp;15598⭐</code></b> <b><code>&nbsp;&nbsp;1177🍴</code></b> [Plandex](https://github.com/plandex-ai/plandex)) - Open source, terminal-based AI programming engine for complex tasks.
 - 🌎 [AI/ML API](aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
+- 🌎 [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source CLI and MCP bridge for discovering and running 2,000+ AI models through one API.
 - 🌎 [Callstack.ai PR Reviewer](callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.
 - 🌎 [Opik](www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.
 - 🌎 [Kiln](getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.


### PR DESCRIPTION
Adds SandBase CLI to the Developer tools list.

- Canonical repository: https://github.com/sandbaseai/cli
- Open-source CLI and MCP bridge for discovering and running 2,000+ AI models through one API

Disclosure: I contribute to SandBase CLI. This is a factual self-submitted entry using the project’s public documentation.