### PR TITLE
Add BulkPublish to Marketing AI Tools

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: Correia-jpv

--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 *You can also find  more comprehensive list on *[Marketing List](https://github.com/correia-jpv/fucking-awesome-ai-tools/blob/main/marketing.md)*
 
 - * 🌎 [Jasper AI](www.jasper.ai/)** - AI-powered tool for generating marketing content like blogs, emails, and ad copy.
+- * 🌎 [BulkPublish](https://www.bulkpublish.com/)** - AI-agent API and MCP server for multi-platform social publishing.
 - * 🌎 [Mutiny](www.mutinyhq.com/)** - Personalization platform to improve website conversions using AI.
 - * 🌎 [Clearbit](clearbit.com/)** - Lead enrichment and data intelligence platform.
 - * 🌎 [Seventh Sense](www.theseventhsense.com/)** - AI tool for email send time optimization.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A curated list of Artificial Intelligence Top Tools
 >
-> Feel free to contribute and also submit your AI tools on [altern.ai](https://altern.ai/?utm_source=awesomeaitools) for free
+> Feel free to contribute and also submit your AI tools on 🌎 [altern.ai](altern.ai/?utm_source=awesomeaitools) for free
 
 Welcome to Awesome AI Tools! Dive into my curated list of AI list, featuring top generative ai tools and LLMs. Eager to contribute or feature your product? Send a PR to this repo—it's free! Join my growing AI list of products and stay on the edge of innovation.
 
@@ -26,382 +26,382 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ## Editor's Choice
 
-- [AI For Developers](https://aifordevelopers.org) - Just a curated list of AI agents, SDKs, coding copilots, and dev-first tools that save you hours — not waste them.
-- [There's an AI](https://theresanai.com) - List of best AI Tools
-- [Notion AI](https://affiliate.notion.so/9po6cx7rvdr6-4y5a7) - Just ask Q&A, and find the info you need in seconds. Get help writing and brainstorming in Notion, not in a separate browser tab.
-- [Murf AI](https://get.murf.ai/v8i9to5ad4oq) - Create voiceover with the most lifelike AI voices.
-- [SaneBox](https://try.sanebox.com/yzkpe5s68xk2) - an email management software as a service that integrates with IMAP and Exchange Web Services email accounts.
-- [MeetGeek](https://get.meetgeek.ai/zmrnb5xlyfs9) - an AI meeting assistant that automatically video records, transcribes, summarizes, and provides the key points from every meeting.
+- 🌎 [AI For Developers](aifordevelopers.org) - Just a curated list of AI agents, SDKs, coding copilots, and dev-first tools that save you hours — not waste them.
+- 🌎 [There's an AI](theresanai.com) - List of best AI Tools
+- 🌎 [Notion AI](affiliate.notion.so/9po6cx7rvdr6-4y5a7) - Just ask Q&A, and find the info you need in seconds. Get help writing and brainstorming in Notion, not in a separate browser tab.
+- 🌎 [Murf AI](get.murf.ai/v8i9to5ad4oq) - Create voiceover with the most lifelike AI voices.
+- 🌎 [SaneBox](try.sanebox.com/yzkpe5s68xk2) - an email management software as a service that integrates with IMAP and Exchange Web Services email accounts.
+- 🌎 [MeetGeek](get.meetgeek.ai/zmrnb5xlyfs9) - an AI meeting assistant that automatically video records, transcribes, summarizes, and provides the key points from every meeting.
 
 
 ## Text
 
 ### Models
 
-> *More complete list of AI Models: [Awesome AI Models](https://github.com/dariubs/awesome-ai-models)*
+> *More complete list of AI Models: <b><code>&nbsp;&nbsp;&nbsp;147⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;18🍴</code></b> [Awesome AI Models](https://github.com/dariubs/awesome-ai-models))*
 
-- [OpenAI API](https://openai.com/api/) - OpenAI's API provides access to GPT-3 and GPT-4 models, which performs a wide variety of natural language tasks, and Codex, which translates natural language to code.
-- [Gopher](https://www.deepmind.com/blog/language-modelling-at-scale-gopher-ethical-considerations-and-retrieval) - Gopher by DeepMind is a 280 billion parameter language model.
-- [OPT](https://huggingface.co/facebook/opt-350m) - Open Pretrained Transformers (OPT) by Facebook is a suite of decoder-only pre-trained transformers. [Announcement](https://ai.facebook.com/blog/democratizing-access-to-large-scale-language-models-with-opt-175b/). [OPT-175B text generation](https://opt.alpa.ai/) hosted by Alpa.
-- [Bloom](https://huggingface.co/docs/transformers/model_doc/bloom) - BLOOM by Hugging Face is a model similar to GPT-3 that has been trained on 46 different languages and 13 programming languages. #opensource
-- [LLaMA](https://ai.facebook.com/blog/large-language-model-llama-meta-ai/) - A foundational, 65-billion-parameter large language model by Meta. #opensource
-- [Llama 2](https://ai.meta.com/llama/) - The next generation of Meta's open source large language model. #opensource
-- [Claude 3](https://claude.ai/) - Talk to Claude, an AI assistant from Anthropic.
-- [Vicuna-13B](https://lmsys.org/blog/2023-03-30-vicuna/) - An open-source chatbot trained by fine-tuning LLaMA on user-shared conversations collected from ShareGPT.
-- [Stable Beluga](https://huggingface.co/stabilityai/StableBeluga1-Delta) - A finetuned LLamma 65B model
-- [Stable Beluga 2](https://huggingface.co/stabilityai/StableBeluga2) - A finetuned LLamma2 70B model
-- [GPT-4o Mini](https://altern.ai/ai/gpt-4o-mini) - *[Review on Altern](https://altern.ai/ai/gpt-4o-mini)* - Advancing cost-efficient intelligence
+- 🌎 [OpenAI API](openai.com/api/) - OpenAI's API provides access to GPT-3 and GPT-4 models, which performs a wide variety of natural language tasks, and Codex, which translates natural language to code.
+- 🌎 [Gopher](www.deepmind.com/blog/language-modelling-at-scale-gopher-ethical-considerations-and-retrieval) - Gopher by DeepMind is a 280 billion parameter language model.
+- 🌎 [OPT](huggingface.co/facebook/opt-350m) - Open Pretrained Transformers (OPT) by Facebook is a suite of decoder-only pre-trained transformers. 🌎 [Announcement](ai.facebook.com/blog/democratizing-access-to-large-scale-language-models-with-opt-175b/). 🌎 [OPT-175B text generation](opt.alpa.ai/) hosted by Alpa.
+- 🌎 [Bloom](huggingface.co/docs/transformers/model_doc/bloom) - BLOOM by Hugging Face is a model similar to GPT-3 that has been trained on 46 different languages and 13 programming languages. #opensource
+- 🌎 [LLaMA](ai.facebook.com/blog/large-language-model-llama-meta-ai/) - A foundational, 65-billion-parameter large language model by Meta. #opensource
+- 🌎 [Llama 2](ai.meta.com/llama/) - The next generation of Meta's open source large language model. #opensource
+- 🌎 [Claude 3](claude.ai/) - Talk to Claude, an AI assistant from Anthropic.
+- 🌎 [Vicuna-13B](lmsys.org/blog/2023-03-30-vicuna/) - An open-source chatbot trained by fine-tuning LLaMA on user-shared conversations collected from ShareGPT.
+- 🌎 [Stable Beluga](huggingface.co/stabilityai/StableBeluga1-Delta) - A finetuned LLamma 65B model
+- 🌎 [Stable Beluga 2](huggingface.co/stabilityai/StableBeluga2) - A finetuned LLamma2 70B model
+- 🌎 [GPT-4o Mini](altern.ai/ai/gpt-4o-mini) -  🌎 [Review on Altern](altern.ai/ai/gpt-4o-mini)* - Advancing cost-efficient intelligence
 
 
 ### Chatbots
 
-- [ChatGPT](https://chatgpt.com) - *[reviews](https://theresanai.com/chatgpt)* - ChatGPT by OpenAI is a large language model that interacts in a conversational way.
-- [Bing Chat](https://www.bing.com/chat) - *[reviews](https://altern.ai/product/bing_chat)* - A conversational AI language model powered by Microsoft Bing.
-- [Gemini](https://gemini.google.com) - *[reviews](https://altern.ai/product/gemini)* - An experimental AI chatbot by Google, powered by the LaMDA model.
-- [Character.AI](https://character.ai/) - *[reviews](https://altern.ai/product/character-ai)* - Character.AI lets you create characters and chat to them.
-- [ChatPDF](https://www.chatpdf.com/) - *[reviews](https://altern.ai/product/chatpdf)* - Chat with any PDF.
-- [ChatSonic](https://writesonic.com/chat) - *[reviews](https://altern.ai/product/chatsonic)* - An AI-powered assistant that enables text and image creation.
-- [Phind](https://www.phind.com/) - *[reviews](https://altern.ai/product/phind)* - Phind is an intelligent search engine and assistant for programmers. Phind is smart enough to proactively ask you questions to clarify its assumptions and to browse the web (or your codebase) when it needs additional context. With our new VS Code extension.
-- [Tiledesk](https://tiledesk.com/) - *[reviews](https://altern.ai/product/tiledesk)* - Open-source LLM-enabled no-code chatbot development framework. Design, test and launch your flows on all your channels in minutes.
-- [AICamp](https://aicamp.so/) - *[reviews](#)* - ChatGPT for Teams
-- [Gali Chat](https://www.galichat.com/) - *[reviews](#)* - Your 24/7 AI Support Assistant that helps you grow your business!
-- [DeepSeek-R1](https://www.deepseek.com) - *[reviews](https://altern.ai/product/deepseek-r1)* - A versatile AI assistant by DeepSeek, designed for conversational interactions, code generation, and creative tasks.
-- [dmwithme](https://dmwithme.com) - AI companion with realistic emotions that can disagree, get moody, and challenge you.
+- 🌎 [ChatGPT](chatgpt.com) -  🌎 [reviews](theresanai.com/chatgpt)* - ChatGPT by OpenAI is a large language model that interacts in a conversational way.
+- 🌎 [Bing Chat](www.bing.com/chat) -  🌎 [reviews](altern.ai/product/bing_chat)* - A conversational AI language model powered by Microsoft Bing.
+- 🌎 [Gemini](gemini.google.com) -  🌎 [reviews](altern.ai/product/gemini)* - An experimental AI chatbot by Google, powered by the LaMDA model.
+- 🌎 [Character.AI](character.ai/) -  🌎 [reviews](altern.ai/product/character-ai)* - Character.AI lets you create characters and chat to them.
+- 🌎 [ChatPDF](www.chatpdf.com/) -  🌎 [reviews](altern.ai/product/chatpdf)* - Chat with any PDF.
+- 🌎 [ChatSonic](writesonic.com/chat) -  🌎 [reviews](altern.ai/product/chatsonic)* - An AI-powered assistant that enables text and image creation.
+- 🌎 [Phind](www.phind.com/) -  🌎 [reviews](altern.ai/product/phind)* - Phind is an intelligent search engine and assistant for programmers. Phind is smart enough to proactively ask you questions to clarify its assumptions and to browse the web (or your codebase) when it needs additional context. With our new VS Code extension.
+- 🌎 [Tiledesk](tiledesk.com/) -  🌎 [reviews](altern.ai/product/tiledesk)* - Open-source LLM-enabled no-code chatbot development framework. Design, test and launch your flows on all your channels in minutes.
+- 🌎 [AICamp](aicamp.so/) - *[reviews](#)* - ChatGPT for Teams
+- 🌎 [Gali Chat](www.galichat.com/) - *[reviews](#)* - Your 24/7 AI Support Assistant that helps you grow your business!
+- 🌎 [DeepSeek-R1](www.deepseek.com) -  🌎 [reviews](altern.ai/product/deepseek-r1)* - A versatile AI assistant by DeepSeek, designed for conversational interactions, code generation, and creative tasks.
+- 🌎 [dmwithme](dmwithme.com) - AI companion with realistic emotions that can disagree, get moody, and challenge you.
 
 
 ### Search engines
 
-- [Kazimir.ai](https://kazimir.ai/) - A search engine designed to search AI-generated images. 
-- [Perplexity AI](https://www.perplexity.ai/) - AI powered search tools.
-- [Metaphor](https://metaphor.systems/) - Language model powered search.
-- [Phind](https://phind.com/) - AI-based search engine.
-- [You.com](https://you.com/) - A search engine built on AI that provides users with a customized search experience while keeping their data 100% private.
-- [Komo AI](https://komo.ai/) - An AI based Search engine which responses quick and short answers.
-- [Telborg](https://telborg.com/) - AI for Climate Research, with data exclusively from governments, international institutions and companies.
-- [MemFree](https://github.com/memfreeme/memfree) - Open Source Hybrid AI Search Engine, Instantly Get Accurate Answers from the Internet, Bookmarks, Notes, and Docs
-- [Refinder AI](https://refinder.ai/) - AI-powered universal search and assistant for work
-- [Agentset.ai](https://agentset.ai/) - Open-source local Semantic Search + RAG for your data
+- 🌎 [Kazimir.ai](kazimir.ai/) - A search engine designed to search AI-generated images. 
+- 🌎 [Perplexity AI](www.perplexity.ai/) - AI powered search tools.
+- 🌎 [Metaphor](metaphor.systems/) - Language model powered search.
+- 🌎 [Phind](phind.com/) - AI-based search engine.
+- 🌎 [You.com](you.com/) - A search engine built on AI that provides users with a customized search experience while keeping their data 100% private.
+- 🌎 [Komo AI](komo.ai/) - An AI based Search engine which responses quick and short answers.
+- 🌎 [Telborg](telborg.com/) - AI for Climate Research, with data exclusively from governments, international institutions and companies.
+- <b><code>&nbsp;&nbsp;1505⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;211🍴</code></b> [MemFree](https://github.com/memfreeme/memfree)) - Open Source Hybrid AI Search Engine, Instantly Get Accurate Answers from the Internet, Bookmarks, Notes, and Docs
+- 🌎 [Refinder AI](refinder.ai/) - AI-powered universal search and assistant for work
+- 🌎 [Agentset.ai](agentset.ai/) - Open-source local Semantic Search + RAG for your data
 
 ### Local search engines
 
-- [privateGPT](https://github.com/imartinez/privateGPT) - Ask questions to your documents without an internet connection, using the power of LLMs.
-- [quivr](https://github.com/StanGirard/quivr) - Dump all your files and chat with it using your generative AI second brain using LLMs & embeddings.
+- <b><code>&nbsp;57491⭐</code></b> <b><code>&nbsp;&nbsp;7613🍴</code></b> [privateGPT](https://github.com/imartinez/privateGPT)) - Ask questions to your documents without an internet connection, using the power of LLMs.
+- <b><code>&nbsp;39458⭐</code></b> <b><code>&nbsp;&nbsp;3728🍴</code></b> [quivr](https://github.com/StanGirard/quivr)) - Dump all your files and chat with it using your generative AI second brain using LLMs & embeddings.
 
 ### Writing assistants
 
-*For a more complete list of AI writing assistants visit: [Awesome AI Writing](https://github.com/xaramore/awesome-ai-writing)*
+*For a more complete list of AI writing assistants visit: <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?🍴</code></b> [Awesome AI Writing](https://github.com/xaramore/awesome-ai-writing))*
 
-- [Jasper](https://www.jasper.ai/) - Create content faster with artificial intelligence.
-- [Compose AI](https://www.compose.ai/) - Compose AI is a free Chrome extension that cuts your writing time by 40% with AI-powered autocompletion.
-- [Rytr](https://rytr.me/) - Rytr is an AI writing assistant that helps you create high-quality content.
-- [wordtune](https://www.wordtune.com/) - Personal writing assistant.
-- [HyperWrite](https://hyperwriteai.com/) - HyperWrite helps you write with confidence and get your work done faster from idea to final draft.
-- [Nexus AI](https://mynexusai.com/) - Nexus AI is a generative cutting-edge AI Platform for writing, coding, voiceovers, research, image creation and beyond.
-- [Moonbeam](https://www.gomoonbeam.com/) - Better blogs in a fraction of the time.
-- [copy.ai](https://www.copy.ai/) - Write better marketing copy and content with AI.
-- [Anyword](https://anyword.com/) - Anyword's AI writing assistant generates effective copy for anyone.
-- [Contenda](https://contenda.co/) - Create the content your audience wants, from content you've already made.
-- [Hypotenuse AI](https://www.hypotenuse.ai/) - Turn a few keywords into original, insightful articles, product descriptions and social media copy.
-- [Lavender](https://www.lavender.ai/) - Lavender email assistant helps you get more replies in less time.
-- [Lex](https://lex.page/) - A word processor with artificial intelligence baked in, so you can write faster.
-- [Jenni](https://jenni.ai/) - Jenni is the ultimate writing assistant that saves you hours of ideation and writing time.
-- [LAIKA](https://www.writewithlaika.com/) - LAIKA trains an artificial intelligence on your own writing to create a personalised creative partner-in-crime.
-- [QuillBot](https://quillbot.com) - AI-powered paraphrasing tool.
-- [Postwise](https://postwise.ai/) - Write tweets, schedule posts and grow your following using AI.
-- [RapidTextAI](https://app.rapidtextai.com/) - Write Advance Articles using Multiple AI Models like GPT4, Gemini, Deepseek and grok.
-- [Copysmith](https://copysmith.ai/) - AI content creation solution for Enterprise & eCommerce.
-- [Yomu](https://www.yomu.ai) - AI writing assistant for students and academics.
-- [Listomatic](https://listomatic.app) - Free and fully configurable real estate listing description generator.
-- [Quick Creator](https://quickcreator.io) - SEO-Optimized Blog platform powered by AI.
-- [Telborg](https://telborg.com/) - Write a high-quality first draft on any Climate topic in minutes
-- [Trolly.ai](https://trolly.ai/) - Trolly.ai can help you in creating professional SEO articles, 2x faster. This tool crafts content that search engines love, propelling you up the rankings.
-- [Dittto.ai](https://dittto.ai) - Fix your hero copy with an AI trained on top SaaS websites.
-- [PulsePost](https://pulsepost.io/) - AI writer that Auto Publishes to your own website
-- [Shy Editor](https://www.shyeditor.com) - A modern AI-assisted writing environment for all types of prose. 
-- [DeepL Write](https://www.deepl.com/write) - AI writing tool that improves written communication.
-- [Headlinesai.pro](https://www.headlinesai.pro/) - This AI powered tool can help you in generating catchy and optimized headlines based on your content for multiple platforms like Youtube, Medium, Indie Hackers and Reddit.
-- [GPTLocalhost](https://gptlocalhost.com/demo/) - A local Word Add-in for you to use local LLM servers in Microsoft Word. Alternative to "Copilot in Word" and completely local.
+- 🌎 [Jasper](www.jasper.ai/) - Create content faster with artificial intelligence.
+- 🌎 [Compose AI](www.compose.ai/) - Compose AI is a free Chrome extension that cuts your writing time by 40% with AI-powered autocompletion.
+- 🌎 [Rytr](rytr.me/) - Rytr is an AI writing assistant that helps you create high-quality content.
+- 🌎 [wordtune](www.wordtune.com/) - Personal writing assistant.
+- 🌎 [HyperWrite](hyperwriteai.com/) - HyperWrite helps you write with confidence and get your work done faster from idea to final draft.
+- 🌎 [Nexus AI](mynexusai.com/) - Nexus AI is a generative cutting-edge AI Platform for writing, coding, voiceovers, research, image creation and beyond.
+- 🌎 [Moonbeam](www.gomoonbeam.com/) - Better blogs in a fraction of the time.
+- 🌎 [copy.ai](www.copy.ai/) - Write better marketing copy and content with AI.
+- 🌎 [Anyword](anyword.com/) - Anyword's AI writing assistant generates effective copy for anyone.
+- 🌎 [Contenda](contenda.co/) - Create the content your audience wants, from content you've already made.
+- 🌎 [Hypotenuse AI](www.hypotenuse.ai/) - Turn a few keywords into original, insightful articles, product descriptions and social media copy.
+- 🌎 [Lavender](www.lavender.ai/) - Lavender email assistant helps you get more replies in less time.
+- 🌎 [Lex](lex.page/) - A word processor with artificial intelligence baked in, so you can write faster.
+- 🌎 [Jenni](jenni.ai/) - Jenni is the ultimate writing assistant that saves you hours of ideation and writing time.
+- 🌎 [LAIKA](www.writewithlaika.com/) - LAIKA trains an artificial intelligence on your own writing to create a personalised creative partner-in-crime.
+- 🌎 [QuillBot](quillbot.com) - AI-powered paraphrasing tool.
+- 🌎 [Postwise](postwise.ai/) - Write tweets, schedule posts and grow your following using AI.
+- 🌎 [RapidTextAI](app.rapidtextai.com/) - Write Advance Articles using Multiple AI Models like GPT4, Gemini, Deepseek and grok.
+- 🌎 [Copysmith](copysmith.ai/) - AI content creation solution for Enterprise & eCommerce.
+- 🌎 [Yomu](www.yomu.ai) - AI writing assistant for students and academics.
+- 🌎 [Listomatic](listomatic.app) - Free and fully configurable real estate listing description generator.
+- 🌎 [Quick Creator](quickcreator.io) - SEO-Optimized Blog platform powered by AI.
+- 🌎 [Telborg](telborg.com/) - Write a high-quality first draft on any Climate topic in minutes
+- 🌎 [Trolly.ai](trolly.ai/) - Trolly.ai can help you in creating professional SEO articles, 2x faster. This tool crafts content that search engines love, propelling you up the rankings.
+- 🌎 [Dittto.ai](dittto.ai) - Fix your hero copy with an AI trained on top SaaS websites.
+- 🌎 [PulsePost](pulsepost.io/) - AI writer that Auto Publishes to your own website
+- 🌎 [Shy Editor](www.shyeditor.com) - A modern AI-assisted writing environment for all types of prose. 
+- 🌎 [DeepL Write](www.deepl.com/write) - AI writing tool that improves written communication.
+- 🌎 [Headlinesai.pro](www.headlinesai.pro/) - This AI powered tool can help you in generating catchy and optimized headlines based on your content for multiple platforms like Youtube, Medium, Indie Hackers and Reddit.
+- 🌎 [GPTLocalhost](gptlocalhost.com/demo/) - A local Word Add-in for you to use local LLM servers in Microsoft Word. Alternative to "Copilot in Word" and completely local.
 
 
 ### ChatGPT extensions
 
-- [Gist AI](https://www.gistai.tech?utm_source=tool_directory&utm_medium=post&utm_campaign=launch) - ChatGPT-powered free Summarizer for Websites, YouTube and PDF.
-- [WebChatGPT](https://chrome.google.com/webstore/detail/webchatgpt-chatgpt-with-i/lpfemeioodjbpieminkklglpmhlngfcn) - Augment your ChatGPT prompts with relevant results from the web.
-- [GPT for Sheets and Docs](https://workspace.google.com/marketplace/app/gpt_for_sheets_and_docs/677318054654) - ChatGPT extension for Google Sheets and Google Docs.
-- [YouTube Summary with ChatGPT](https://chrome.google.com/webstore/detail/youtube-summary-with-chat/nmmicjeknamkfloonkhhcjmomieiodli) - Use ChatGPT to summarize YouTube videos.
-- [ChatGPT Prompt Genius](https://chrome.google.com/webstore/detail/chatgpt-prompt-genius/jjdnakkfjnnbbckhifcfchagnpofjffo) - Discover, share, import, and use the best prompts for ChatGPT & save your chat history locally.
-- [ChatGPT for Search Engines](https://chrome.google.com/webstore/detail/chatgpt-for-search-engine/feeonheemodpkdckaljcjogdncpiiban) - Display ChatGPT response alongside Google, Bing, and DuckDuckGo search results.
-- [ShareGPT](https://sharegpt.com/) - Share your ChatGPT conversations and explore conversations shared by others.
-- [Merlin](https://merlin.foyer.work/) - ChatGPT Plus extension on all websites.
-- [ChatGPT Writer](https://chatgptwriter.ai/) - Generate entire emails and messages using ChatGPT AI.
-- [ChatGPT for Jupyter](https://github.com/TiesdeKok/chat-gpt-jupyter-extension) - Add various helper functions in Jupyter Notebooks and Jupyter Lab, powered by ChatGPT.
-- [editGPT](https://www.editgpt.app/) - Easily proofread, edit, and track changes to your content in chatGPT.
-- [Chatbot UI](https://www.chatbotui.com/) - An open source ChatGPT UI. [Source code](https://github.com/mckaywrigley/chatbot-ui).
-- [Forefront](https://www.forefront.ai/) - A Better ChatGPT Experience.
-- [AI Character for GPT](https://chromewebstore.google.com/detail/ai-character-for-gpt/daoeioifimkjegafelcaljboknjkkohh) - One click to curate AI chatbot, including ChatGPT, Google Bard to improve AI responses.
+- 🌎 [Gist AI](www.gistai.tech?utm_source=tool_directory&utm_medium=post&utm_campaign=launch) - ChatGPT-powered free Summarizer for Websites, YouTube and PDF.
+- 🌎 [WebChatGPT](chrome.google.com/webstore/detail/webchatgpt-chatgpt-with-i/lpfemeioodjbpieminkklglpmhlngfcn) - Augment your ChatGPT prompts with relevant results from the web.
+- 🌎 [GPT for Sheets and Docs](workspace.google.com/marketplace/app/gpt_for_sheets_and_docs/677318054654) - ChatGPT extension for Google Sheets and Google Docs.
+- 🌎 [YouTube Summary with ChatGPT](chrome.google.com/webstore/detail/youtube-summary-with-chat/nmmicjeknamkfloonkhhcjmomieiodli) - Use ChatGPT to summarize YouTube videos.
+- 🌎 [ChatGPT Prompt Genius](chrome.google.com/webstore/detail/chatgpt-prompt-genius/jjdnakkfjnnbbckhifcfchagnpofjffo) - Discover, share, import, and use the best prompts for ChatGPT & save your chat history locally.
+- 🌎 [ChatGPT for Search Engines](chrome.google.com/webstore/detail/chatgpt-for-search-engine/feeonheemodpkdckaljcjogdncpiiban) - Display ChatGPT response alongside Google, Bing, and DuckDuckGo search results.
+- 🌎 [ShareGPT](sharegpt.com/) - Share your ChatGPT conversations and explore conversations shared by others.
+- 🌎 [Merlin](merlin.foyer.work/) - ChatGPT Plus extension on all websites.
+- 🌎 [ChatGPT Writer](chatgptwriter.ai/) - Generate entire emails and messages using ChatGPT AI.
+- <b><code>&nbsp;&nbsp;&nbsp;309⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;55🍴</code></b> [ChatGPT for Jupyter](https://github.com/TiesdeKok/chat-gpt-jupyter-extension)) - Add various helper functions in Jupyter Notebooks and Jupyter Lab, powered by ChatGPT.
+- 🌎 [editGPT](www.editgpt.app/) - Easily proofread, edit, and track changes to your content in chatGPT.
+- 🌎 [Chatbot UI](www.chatbotui.com/) - An open source ChatGPT UI. <b><code>&nbsp;33342⭐</code></b> <b><code>&nbsp;&nbsp;9424🍴</code></b> [Source code](https://github.com/mckaywrigley/chatbot-ui)).
+- 🌎 [Forefront](www.forefront.ai/) - A Better ChatGPT Experience.
+- 🌎 [AI Character for GPT](chromewebstore.google.com/detail/ai-character-for-gpt/daoeioifimkjegafelcaljboknjkkohh) - One click to curate AI chatbot, including ChatGPT, Google Bard to improve AI responses.
 
 ### Productivity
 
-- [Mem](https://mem.ai/) - Mem is the world's first AI-powered workspace that's personalized to you. Amplify your creativity, automate the mundane, and stay organized automatically.
-- [Taskade](https://www.taskade.com/) -  Build, train, and deploy autonomous AI agents for task management, team collaboration, and workflow automation—all within a unified workspace.
-- [Notion AI](https://www.notion.so/product/ai) - Write better, more efficient notes and docs.
-- [Nekton AI](https://nekton.ai) - Automate your workflows with AI. Describe your workflows step by step in plain language.
-- [Elephas](https://elephas.app/?ref=mahseema-awesome-ai-tools) - Personal AI writing assistant for the Mac.
-- [Lemmy](https://lemmy.co/?ref=mahseema-awesome-ai-tools) - Autonomous AI Assistant for Work.
-- [Google Sheets Formula Generator](https://bettersheets.co/google-sheets-formula-generator?ref=mahseema-awesome-ai-tools) - Forget about frustrating formulas in Google Sheets.
-- [CreateEasily](https://createeasily.com/?ref=mahseema-awesome-ai-tools) - Free speech-to-text tool for content creators that accurately transcribes audio & video files up to 2GB.
-- [Cosmos](https://meetcosmos.com/) - Use AI locally and offline to search your media files by their content, find similar images or video scenes using reference images, and transcribe video.
-- [aiPDF](https://aipdf.ai) - The most advanced AI document assistant
-- [Summary With AI](https://www.summarywithai.com/) - Summarize any long PDF with AI. Comprehensive summaries using information from all pages of a document.
-- [Emilio](https://getemil.io?ref=mahseema-awesome-ai-tools) - Stop drowning in emails - Emilio prioritizes and automates your email, saving 60% of your time
-- [Pieces](https://pieces.app/) - AI-enabled productivity tool designed to supercharge developer efficiency,with an on-device copilot that helps capture, enrich, and reuse useful materials, streamline collaboration, and solve complex problems through a contextual understanding of dev workflow
-- [Huntr AI Resume Builder](https://huntr.co/product/ai-resume-builder/?ref=mahseema-awesome-ai-tools) - Craft the perfect resume, with a little help from AI. Huntr’s customizable AI Resume Builder will help you craft a well-written, ATS-friendly resume to help you land more interviews.
-- [Chat With PDF by Copilot.us](https://copilot.us/apps/chat-with-pdf) - An AI app that enables dialogue with PDF documents, supporting interactions with multiple files simultaneously through language models.
-- [Recall](https://www.getrecall.ai/) - Summarize Anything, Forget Nothing
-- [Talently AI](https://interview.talently.ai/?utm_source=mahseema-awesome-ai-tool&utm_medium=c_and_p&utm_campaign=tool-listing) - An Al interviewer that conducts live, conversational interviews and gives real-time evaluations to effortlessly identify top performers and scale your recruitment process. 
-- [TailorTask](https://wwww.tailortask.ai) - Automate any boring and repetitive task, without having to learn a new tool
-- [AnkiDecks AI](https://anki-decks.com) - Create Flashcards 10x faster. Generate Anki Flashcards from any File or Text with AI.
-- [AI for Google Slides](https://www.aiforgoogleslides.com/) - AI presentation maker for Google Slides
-- [FARSITE](https://far.site/) - AI-powered Compliance Software for U.S. Government Contractors
-- [GOSH](https://gosh.app) - Free AI Price Tracker - Track any price of any product at any store using AI
-- [BrainSoup](https://www.nurgo-software.com/products/brainsoup) Multi-agent & multi-LLM native client where AIs can remember, react to events, use tools, leverage local and external resources, and work together autonomously.
-- [MindPal](https://mindpal.space/) - Build your AI Second Brain with a team of AI agents and multi-agent workflow
-- [fabric](https://github.com/danielmiessler/fabric/) - Apply AI to everyday challenges in the comfort of your terminal. Help’s to get better results with tried and tested library of prompt pattern’s.
-- [Riffo](https://riffo.ai/) - An AI-powered file management tool for bulk renaming and automatic folder organization.
-- [SlidesWizard](https://slideswizard.io) - Create Presentations 10x faster. Generate PowerPoint and Google Slides presentations about any topic with AI
-- [Transgate](https://transgate.ai/) - AI Speech to Text
-- [RabbitHoles AI](https://www.rabbitholes.ai/) - Chat with AI on an Infinite Canvas
-- [Rember](https://www.rember.com/) - A simple yet powerful spaced repetition system designed to help you remember more.
-- [Qurate](https://qurate.appcradle.net/) - AI Quote Companion, which can help in finding relavant quotes according to the context.
-- [FirmOS](https://www.firmos.ai/) - AI-Powered Automation for Accounting Firms
-- [Whisper API](https://whisper-api.com) - Whisper API is a Transcription API Powered By OpenAI Whisper model. Get 5 free transcriptions daily (no duration limits) with robust control over the model's parameters like size, temperature, beam size and more.
-- [Smmry](https://smmry.com/) - Summarize Long Content Into Clear Insights
-- [Nudge AI](https://getnudgeai.com/) - Ambient AI Scribe for Healthcare
-- [Summara](https://summara.io/) - YouTube AI Summary and Transcript widget
-- [Mocha](https://getmocha.com) - AI app builder
-- [Marblism](https://marblism.com) - AI Employees for your business
-- [Spell](https://spellapp.com) - Spell is the AI alternative to Google Docs
-- [Kosmik](https://www.kosmik.app) - AI moodboarding platform
-- [Magic Potion](https://www.magicpotion.app) - Visual AI Prompt Editor
-- [MinusX](https://minusx.ai/) - Have an AI Analyst answer all your data questions reliably on Metabase
-- [Excelmatic](https://excelmatic.ai) - AI-Powered Excel Data Analysis and Visualization, Skip the functions—just upload, chat, and watch your data turn into insights and visuals.
-- [Langfa.st](https://langfa.st/) - A fast, no-signup playground to test and share AI prompt templates
-- [SalesAgent Chat](https://www.salesagent.chat) - AI Sales Coach & Copilot for real-time support
-- [ReBillion.ai](https://tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
-- [Perch Reader](https://perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
-- [X-doc AI](https://x-doc.ai/) - The most accurate AI translator
+- 🌎 [Mem](mem.ai/) - Mem is the world's first AI-powered workspace that's personalized to you. Amplify your creativity, automate the mundane, and stay organized automatically.
+- 🌎 [Taskade](www.taskade.com/) -  Build, train, and deploy autonomous AI agents for task management, team collaboration, and workflow automation—all within a unified workspace.
+- 🌎 [Notion AI](www.notion.so/product/ai) - Write better, more efficient notes and docs.
+- 🌎 [Nekton AI](nekton.ai) - Automate your workflows with AI. Describe your workflows step by step in plain language.
+- 🌎 [Elephas](elephas.app/?ref=mahseema-awesome-ai-tools) - Personal AI writing assistant for the Mac.
+- 🌎 [Lemmy](lemmy.co/?ref=mahseema-awesome-ai-tools) - Autonomous AI Assistant for Work.
+- 🌎 [Google Sheets Formula Generator](bettersheets.co/google-sheets-formula-generator?ref=mahseema-awesome-ai-tools) - Forget about frustrating formulas in Google Sheets.
+- 🌎 [CreateEasily](createeasily.com/?ref=mahseema-awesome-ai-tools) - Free speech-to-text tool for content creators that accurately transcribes audio & video files up to 2GB.
+- 🌎 [Cosmos](meetcosmos.com/) - Use AI locally and offline to search your media files by their content, find similar images or video scenes using reference images, and transcribe video.
+- 🌎 [aiPDF](aipdf.ai) - The most advanced AI document assistant
+- 🌎 [Summary With AI](www.summarywithai.com/) - Summarize any long PDF with AI. Comprehensive summaries using information from all pages of a document.
+- 🌎 [Emilio](getemil.io?ref=mahseema-awesome-ai-tools) - Stop drowning in emails - Emilio prioritizes and automates your email, saving 60% of your time
+- 🌎 [Pieces](pieces.app/) - AI-enabled productivity tool designed to supercharge developer efficiency,with an on-device copilot that helps capture, enrich, and reuse useful materials, streamline collaboration, and solve complex problems through a contextual understanding of dev workflow
+- 🌎 [Huntr AI Resume Builder](huntr.co/product/ai-resume-builder/?ref=mahseema-awesome-ai-tools) - Craft the perfect resume, with a little help from AI. Huntr’s customizable AI Resume Builder will help you craft a well-written, ATS-friendly resume to help you land more interviews.
+- 🌎 [Chat With PDF by Copilot.us](copilot.us/apps/chat-with-pdf) - An AI app that enables dialogue with PDF documents, supporting interactions with multiple files simultaneously through language models.
+- 🌎 [Recall](www.getrecall.ai/) - Summarize Anything, Forget Nothing
+- 🌎 [Talently AI](interview.talently.ai/?utm_source=mahseema-awesome-ai-tool&utm_medium=c_and_p&utm_campaign=tool-listing) - An Al interviewer that conducts live, conversational interviews and gives real-time evaluations to effortlessly identify top performers and scale your recruitment process. 
+- 🌎 [TailorTask](wwww.tailortask.ai) - Automate any boring and repetitive task, without having to learn a new tool
+- 🌎 [AnkiDecks AI](anki-decks.com) - Create Flashcards 10x faster. Generate Anki Flashcards from any File or Text with AI.
+- 🌎 [AI for Google Slides](www.aiforgoogleslides.com/) - AI presentation maker for Google Slides
+- 🌎 [FARSITE](far.site/) - AI-powered Compliance Software for U.S. Government Contractors
+- 🌎 [GOSH](gosh.app) - Free AI Price Tracker - Track any price of any product at any store using AI
+- 🌎 [BrainSoup](www.nurgo-software.com/products/brainsoup) Multi-agent & multi-LLM native client where AIs can remember, react to events, use tools, leverage local and external resources, and work together autonomously.
+- 🌎 [MindPal](mindpal.space/) - Build your AI Second Brain with a team of AI agents and multi-agent workflow
+- <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?🍴</code></b> [fabric](https://github.com/danielmiessler/fabric/)) - Apply AI to everyday challenges in the comfort of your terminal. Help’s to get better results with tried and tested library of prompt pattern’s.
+- 🌎 [Riffo](riffo.ai/) - An AI-powered file management tool for bulk renaming and automatic folder organization.
+- 🌎 [SlidesWizard](slideswizard.io) - Create Presentations 10x faster. Generate PowerPoint and Google Slides presentations about any topic with AI
+- 🌎 [Transgate](transgate.ai/) - AI Speech to Text
+- 🌎 [RabbitHoles AI](www.rabbitholes.ai/) - Chat with AI on an Infinite Canvas
+- 🌎 [Rember](www.rember.com/) - A simple yet powerful spaced repetition system designed to help you remember more.
+- 🌎 [Qurate](qurate.appcradle.net/) - AI Quote Companion, which can help in finding relavant quotes according to the context.
+- 🌎 [FirmOS](www.firmos.ai/) - AI-Powered Automation for Accounting Firms
+- 🌎 [Whisper API](whisper-api.com) - Whisper API is a Transcription API Powered By OpenAI Whisper model. Get 5 free transcriptions daily (no duration limits) with robust control over the model's parameters like size, temperature, beam size and more.
+- 🌎 [Smmry](smmry.com/) - Summarize Long Content Into Clear Insights
+- 🌎 [Nudge AI](getnudgeai.com/) - Ambient AI Scribe for Healthcare
+- 🌎 [Summara](summara.io/) - YouTube AI Summary and Transcript widget
+- 🌎 [Mocha](getmocha.com) - AI app builder
+- 🌎 [Marblism](marblism.com) - AI Employees for your business
+- 🌎 [Spell](spellapp.com) - Spell is the AI alternative to Google Docs
+- 🌎 [Kosmik](www.kosmik.app) - AI moodboarding platform
+- 🌎 [Magic Potion](www.magicpotion.app) - Visual AI Prompt Editor
+- 🌎 [MinusX](minusx.ai/) - Have an AI Analyst answer all your data questions reliably on Metabase
+- 🌎 [Excelmatic](excelmatic.ai) - AI-Powered Excel Data Analysis and Visualization, Skip the functions—just upload, chat, and watch your data turn into insights and visuals.
+- 🌎 [Langfa.st](langfa.st/) - A fast, no-signup playground to test and share AI prompt templates
+- 🌎 [SalesAgent Chat](www.salesagent.chat) - AI Sales Coach & Copilot for real-time support
+- 🌎 [ReBillion.ai](tc.rebillion.ai/) - AI-powered transaction coordination and workflow automation for real estate professionals
+- 🌎 [Perch Reader](perch.app/) - Free blog and newsletter aggregator with AI summaries and text-to-speech
+- 🌎 [X-doc AI](x-doc.ai/) - The most accurate AI translator
 
 
 ### Meeting assistants
 
-- [Otter.ai](https://otter.ai/) - A meeting assistant that records audio, writes notes, automatically captures slides, and generates summaries.
-- [Cogram](https://www.cogram.com/) - Cogram takes automatic notes in virtual meetings and identifies action items.
-- [Sybill](https://www.sybill.ai/) - Sybill generates summaries of sales calls, including next steps, pain points and areas of interest, by combining transcript and emotion-based insights.
-- [Loopin AI](https://www.loopinhq.com/) - Loopin is a collaborative meeting workspace that not only enables you to record, transcribe & summaries meetings using AI, but also enables you to auto-organise meeting notes on top of your calendar.
-- [Scribbl](https://www.scribbl.co) - AI Meeting Notes
+- 🌎 [Otter.ai](otter.ai/) - A meeting assistant that records audio, writes notes, automatically captures slides, and generates summaries.
+- 🌎 [Cogram](www.cogram.com/) - Cogram takes automatic notes in virtual meetings and identifies action items.
+- 🌎 [Sybill](www.sybill.ai/) - Sybill generates summaries of sales calls, including next steps, pain points and areas of interest, by combining transcript and emotion-based insights.
+- 🌎 [Loopin AI](www.loopinhq.com/) - Loopin is a collaborative meeting workspace that not only enables you to record, transcribe & summaries meetings using AI, but also enables you to auto-organise meeting notes on top of your calendar.
+- 🌎 [Scribbl](www.scribbl.co) - AI Meeting Notes
 
 ### Academia
 
-- [Elicit](https://elicit.org/) - Elicit uses language models to help you automate research workflows, like parts of literature review.
-- [genei](https://www.genei.io/) - Summarise academic articles in seconds and save 80% on your research times.
-- [Explainpaper](https://www.explainpaper.com/) - A better way to read academic papers. Upload a paper, highlight confusing text, get an explanation.
-- [Galactica](https://galactica.org/) - A large language model for science. Can summarize academic literature, solve math problems, generate Wiki articles, write scientific code, annotate molecules and proteins, and more. [Model API](https://github.com/paperswithcode/galai).
-- [Consensus](https://consensus.app/search/) - Consensus is a search engine that uses AI to find answers in scientific research.
-- [Sourcely](https://www.sourcely.net/) - Academic Citation Finding Tool with AI
-- [SciSpace](https://scispace.com/) - AI Chat for scientific PDFs.
-- [NotebookLM](https://notebooklm.google.com/) - AI Chat on your own document, link and text resources.
-- [Mathos AI](https://www.mathgptpro.com/) - Best AI math solver, calculator & tutor.
+- 🌎 [Elicit](elicit.org/) - Elicit uses language models to help you automate research workflows, like parts of literature review.
+- 🌎 [genei](www.genei.io/) - Summarise academic articles in seconds and save 80% on your research times.
+- 🌎 [Explainpaper](www.explainpaper.com/) - A better way to read academic papers. Upload a paper, highlight confusing text, get an explanation.
+- 🌎 [Galactica](galactica.org/) - A large language model for science. Can summarize academic literature, solve math problems, generate Wiki articles, write scientific code, annotate molecules and proteins, and more. <b><code>&nbsp;&nbsp;2741⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;268🍴</code></b> [Model API](https://github.com/paperswithcode/galai)).
+- 🌎 [Consensus](consensus.app/search/) - Consensus is a search engine that uses AI to find answers in scientific research.
+- 🌎 [Sourcely](www.sourcely.net/) - Academic Citation Finding Tool with AI
+- 🌎 [SciSpace](scispace.com/) - AI Chat for scientific PDFs.
+- 🌎 [NotebookLM](notebooklm.google.com/) - AI Chat on your own document, link and text resources.
+- 🌎 [Mathos AI](www.mathgptpro.com/) - Best AI math solver, calculator & tutor.
 
 ### Customer Support
-- [SiteGPT](https://sitegpt.ai/?ref=mahseema-awesome-ai-tools) - Make AI your expert customer support agent.
-- [GPTHelp.ai](https://gpthelp.ai/?ref=mahseema-awesome-ai-tools) - ChatGPT for your website / AI customer support chatbot.
-- [SiteSpeakAI](https://sitespeak.ai) - Automate your customer support with AI.
-- [Dear AI](https://www.dearai.online) - Supercharge Customer Services and boost sales with AI Chatbot.
-- [Inline Help](https://inlinehelp.com) - Answer customer questions before they ask
-- [Aidbase](https://www.aidbase.ai) - AI-Powered Support for your SaaS startup.
-- [Twig](https://www.twig.so/) - Twig is an AI assistant that resolves customer issues instantly, supporting both users and support agents 24/7.
+- 🌎 [SiteGPT](sitegpt.ai/?ref=mahseema-awesome-ai-tools) - Make AI your expert customer support agent.
+- 🌎 [GPTHelp.ai](gpthelp.ai/?ref=mahseema-awesome-ai-tools) - ChatGPT for your website / AI customer support chatbot.
+- 🌎 [SiteSpeakAI](sitespeak.ai) - Automate your customer support with AI.
+- 🌎 [Dear AI](www.dearai.online) - Supercharge Customer Services and boost sales with AI Chatbot.
+- 🌎 [Inline Help](inlinehelp.com) - Answer customer questions before they ask
+- 🌎 [Aidbase](www.aidbase.ai) - AI-Powered Support for your SaaS startup.
+- 🌎 [Twig](www.twig.so/) - Twig is an AI assistant that resolves customer issues instantly, supporting both users and support agents 24/7.
 
 
 ### Other text generators
 
-- [EmailTriager](https://www.emailtriager.com/) - Use AI to automatically draft email replies in the background.
-- [AI Poem Generator](https://www.aipoemgenerator.org) - AI Poem Generator writes a beautiful rhyming poem for you on any subject, given a text prompt.
-- [Never Jobless LinkedIn Message Generator](https://neverjobless.com/?ref=mahseema-awesome-ai-tools) - Maximize Your Interview Chances with AI-Powered LinkedIn Messaging.
+- 🌎 [EmailTriager](www.emailtriager.com/) - Use AI to automatically draft email replies in the background.
+- 🌎 [AI Poem Generator](www.aipoemgenerator.org) - AI Poem Generator writes a beautiful rhyming poem for you on any subject, given a text prompt.
+- 🌎 [Never Jobless LinkedIn Message Generator](neverjobless.com/?ref=mahseema-awesome-ai-tools) - Maximize Your Interview Chances with AI-Powered LinkedIn Messaging.
 
 
 ### Developer tools
 
-- [Ollama](https://ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
-- [co:here](https://cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
-- [Haystack](https://haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.
-- [Keploy](https://keploy.io/) - Open source Tool for converting user traffic to Test Cases and Data Stubs.
-- [LangChain](https://langchain.com/) - A framework for developing applications powered by language models.
-- [Portia AI](https://www.portialabs.ai/) - Open source framework for building agents that pre-express their planned actions, share their progress and can be interrupted by a human. [#opensource](https://github.com/portiaAI/portia-sdk-python)
-- [gpt4all](https://github.com/nomic-ai/gpt4all) - A chatbot trained on a massive collection of clean assistant data including code, stories, and dialogue.
-- [LMQL](https://lmql.ai/) - LMQL is a query language for large language models.
-- [LlamaIndex](https://www.llamaindex.ai/) - A data framework for building LLM applications over external data.
-- [Langfuse](https://langfuse.com/) - Open-source LLM engineering platform that helps teams collaboratively debug, analyze, and iterate on their LLM applications. [#opensource](https://github.com/langfuse/langfuse)
-- [Phoenix](https://phoenix.arize.com/) - Open-source tool for ML observability that runs in your notebook environment, by Arize. Monitor and fine-tune LLM, CV, and tabular models.
-- [Prediction Guard](https://www.predictionguard.com/) - Seamlessly integrate private, controlled, and compliant Large Language Models (LLM) functionality.
-- [Portkey](https://portkey.ai/) - Full-stack LLMOps platform to monitor, manage, and improve LLM-based apps.
-- [OpenAI Downtime Monitor](https://status.portkey.ai/) - Free tool that tracks API uptime and latencies for various OpenAI models and other LLM providers.
-- [ChatWithCloud](https://chatwithcloud.ai/) - CLI allowing you to interact with AWS Cloud using human language inside your Terminal.
-- [SinglebaseCloud](https://singlebase.cloud) - AI-powered backend platform with Vector DB, DocumentDB, Auth, and more to speed up app development.
-- [Maxim AI](https://www.getmaxim.ai/) - A generative AI evaluation and observability platform, empowering modern AI teams to ship products with quality, reliability, and speed.
-- [Wordware](https://www.wordware.ai) - A web-hosted IDE where non-technical domain experts work with AI Engineers to build task-specific AI agents. It approaches prompting as a new programming language rather than low/no-code blocks.
-- [CodeRabbit](https://coderabbit.ai/) - An AI-powered code review tool that helps developers improve code quality and productivity.
-- [Pagerly](https://www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  
-- [Hexabot](https://hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
-- [Plandex](https://github.com/plandex-ai/plandex) - Open source, terminal-based AI programming engine for complex tasks.
-- [AI/ML API](https://aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
-- [Callstack.ai PR Reviewer](https://callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.
-- [Opik](https://www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.
-- [Kiln](https://getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.
-- [Calmo](https://getcalmo.com/) - Debug Production x10 Faster with AI.
-- [Cleanlab](https://help.cleanlab.ai/tlm/) - Detect and remediate hallucinations in any LLM application.
-- [Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - CLI that provides command completion, command translation using generative AI to translate intent to commands, and a full agentic chat interface with context management that helps you write code.
-- [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows.
-- [VoltAgent](https://github.com/voltagent/voltagent) - A TypeScript framework for building and running AI agents with tools, memory, and visibility.
-- [Notte](https://github.com/nottelabs/notte) - Notte is the fastest, most reliable Browser Using Agents framework
-- [TensorZero](https://www.tensorzero.com/) - An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.
-- [ToolHive](https://github.com/stacklok/toolhive) – Find the right MCP server for your task and deploy with one click. 
-- [StarOps](https://ingenimax.ai) - AI Platform Engineer
-- [AgentDock](https://agentdock.ai) - Unified infrastructure for AI agents and automation. One API key for all services instead of managing dozens. Build production-ready agents without operational complexity.
-- [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
-- [Rysa AI](https://www.rysa.ai) - AI GTM Automation Agent
-- [Agenta](https://agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. [#opensource](https://github.com/agenta-ai/agenta)
+- 🌎 [Ollama](ollama.com/) -  Load and run large LLMs locally to use in your terminal or build your apps.
+- 🌎 [co:here](cohere.ai/) - Cohere provides access to advanced Large Language Models and NLP tools.
+- 🌎 [Haystack](haystack.deepset.ai/) - A framework for building NLP applications (e.g. agents, semantic search, question-answering) with language models.
+- 🌎 [Keploy](keploy.io/) - Open source Tool for converting user traffic to Test Cases and Data Stubs.
+- 🌎 [LangChain](langchain.com/) - A framework for developing applications powered by language models.
+- 🌎 [Portia AI](www.portialabs.ai/) - Open source framework for building agents that pre-express their planned actions, share their progress and can be interrupted by a human. <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?🍴</code></b> [#opensource](https://github.com/portiaAI/portia-sdk-python))
+- <b><code>&nbsp;77386⭐</code></b> <b><code>&nbsp;&nbsp;8294🍴</code></b> [gpt4all](https://github.com/nomic-ai/gpt4all)) - A chatbot trained on a massive collection of clean assistant data including code, stories, and dialogue.
+- 🌎 [LMQL](lmql.ai/) - LMQL is a query language for large language models.
+- 🌎 [LlamaIndex](www.llamaindex.ai/) - A data framework for building LLM applications over external data.
+- 🌎 [Langfuse](langfuse.com/) - Open-source LLM engineering platform that helps teams collaboratively debug, analyze, and iterate on their LLM applications. <b><code>&nbsp;34085⭐</code></b> <b><code>&nbsp;&nbsp;3680🍴</code></b> [#opensource](https://github.com/langfuse/langfuse))
+- 🌎 [Phoenix](phoenix.arize.com/) - Open-source tool for ML observability that runs in your notebook environment, by Arize. Monitor and fine-tune LLM, CV, and tabular models.
+- 🌎 [Prediction Guard](www.predictionguard.com/) - Seamlessly integrate private, controlled, and compliant Large Language Models (LLM) functionality.
+- 🌎 [Portkey](portkey.ai/) - Full-stack LLMOps platform to monitor, manage, and improve LLM-based apps.
+- 🌎 [OpenAI Downtime Monitor](status.portkey.ai/) - Free tool that tracks API uptime and latencies for various OpenAI models and other LLM providers.
+- 🌎 [ChatWithCloud](chatwithcloud.ai/) - CLI allowing you to interact with AWS Cloud using human language inside your Terminal.
+- 🌎 [SinglebaseCloud](singlebase.cloud) - AI-powered backend platform with Vector DB, DocumentDB, Auth, and more to speed up app development.
+- 🌎 [Maxim AI](www.getmaxim.ai/) - A generative AI evaluation and observability platform, empowering modern AI teams to ship products with quality, reliability, and speed.
+- 🌎 [Wordware](www.wordware.ai) - A web-hosted IDE where non-technical domain experts work with AI Engineers to build task-specific AI agents. It approaches prompting as a new programming language rather than low/no-code blocks.
+- 🌎 [CodeRabbit](coderabbit.ai/) - An AI-powered code review tool that helps developers improve code quality and productivity.
+- 🌎 [Pagerly](www.pagerly.io) - Your Operations Co-pilot on Slack/Teams. It assists and prompts oncall with relevant information to debug issues.  
+- 🌎 [Hexabot](hexabot.ai) - A Open-source No-Code tool to build your AI Chatbot / Agent (multi-lingual, multi-channel, LLM, NLU, + ability to develop custom extensions)
+- <b><code>&nbsp;15615⭐</code></b> <b><code>&nbsp;&nbsp;1175🍴</code></b> [Plandex](https://github.com/plandex-ai/plandex)) - Open source, terminal-based AI programming engine for complex tasks.
+- 🌎 [AI/ML API](aimlapi.com/?utm_source=github+of+altern.ai) - AI/ML API gives developers access to 100+ AI models with one API.
+- 🌎 [Callstack.ai PR Reviewer](callstack.ai/pr-reviewer) - Automated Code Reviews: Find Bugs, Fix Security Issues, and Speed Up Performance.
+- 🌎 [Opik](www.comet.com/site/products/opik/) - Evaluate, test, and ship LLM applications with a suite of observability tools to calibrate language model outputs across your dev and production lifecycle.
+- 🌎 [Kiln](getkiln.ai) - Intuitive app to build your own AI models. Includes no-code synthetic data generation, fine-tuning, dataset collaboration, and more.
+- 🌎 [Calmo](getcalmo.com/) - Debug Production x10 Faster with AI.
+- 🌎 [Cleanlab](help.cleanlab.ai/tlm/) - Detect and remediate hallucinations in any LLM application.
+- 🌎 [Amazon Q Developer CLI](docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - CLI that provides command completion, command translation using generative AI to translate intent to commands, and a full agentic chat interface with context management that helps you write code.
+- <b><code>&nbsp;&nbsp;1045⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;145🍴</code></b> [Agentic Radar](https://github.com/splx-ai/agentic-radar)) - Open-source CLI security scanner for agentic workflows.
+- <b><code>&nbsp;10521⭐</code></b> <b><code>&nbsp;&nbsp;1116🍴</code></b> [VoltAgent](https://github.com/voltagent/voltagent)) - A TypeScript framework for building and running AI agents with tools, memory, and visibility.
+- <b><code>&nbsp;&nbsp;2000⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;183🍴</code></b> [Notte](https://github.com/nottelabs/notte)) - Notte is the fastest, most reliable Browser Using Agents framework
+- 🌎 [TensorZero](www.tensorzero.com/) - An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation.
+- <b><code>&nbsp;&nbsp;2066⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;283🍴</code></b> [ToolHive](https://github.com/stacklok/toolhive)) – Find the right MCP server for your task and deploy with one click. 
+- 🌎 [StarOps](ingenimax.ai) - AI Platform Engineer
+- 🌎 [AgentDock](agentdock.ai) - Unified infrastructure for AI agents and automation. One API key for all services instead of managing dozens. Build production-ready agents without operational complexity.
+- 🌎 [Codeflash](www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time.
+- 🌎 [Rysa AI](www.rysa.ai) - AI GTM Automation Agent
+- 🌎 [Agenta](agenta.ai/) - Open-source LLMOps platform for prompt management, LLM evaluation, and observability. Build, evaluate, and monitor production-grade LLM applications. <b><code>&nbsp;&nbsp;4675⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;661🍴</code></b> [#opensource](https://github.com/agenta-ai/agenta))
 
 
 ## Code
 
-- [GitHub Copilot](https://github.com/features/copilot) - GitHub Copilot uses the OpenAI Codex to suggest code and entire functions in real-time, right from your editor.
-- [poorcoder](https://github.com/vgrichina/poorcoder) - Lightweight Bash scripts that enhance your terminal coding workflow with web-based AI assistants like Claude or Grok without disrupting your development process.
-- [OpenAI Codex](https://platform.openai.com/docs/guides/code/) - An AI system by OpenAI that translates natural language to code.
-- [Ghostwriter](https://blog.replit.com/ai) - An AI-powered pair programmer by Replit.
-- [GoCodeo](https://www.gocodeo.com/)- An AI Coding & Testing Agent.
-- [Amazon Q Developer]([https://aws.amazon.com/codewhisperer/](https://aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el)) - AI coding assistant with extensions for IDEs such as VS Code and IntelliJ IDEA that provides both chat and agentic workflows.
-- [Amazon CodeWhisperer](https://aws.amazon.com/codewhisperer/) - Build applications faster with the ML-powered coding companion.
-- [tabnine](https://www.tabnine.com/) - Code faster with whole-line & full-function code completions.
-- [Stenography](https://stenography.dev/) - Automatic code documentation.
-- [Mintlify](https://mintlify.com/) - AI powered documentation writer.
-- [Debuild](https://debuild.app/) - AI-powered low-code tool for web apps.
-- [AI2sql](https://www.ai2sql.io/) - With AI2sql, engineers and non-engineers can easily write efficient, error-free SQL queries without knowing SQL.
-- [CodiumAI](https://www.codium.ai/) - With CodiumAI, you get non-trivial tests suggested right inside your IDE, so you stay confident when you push.
-- [PR-Agent](https://github.com/Codium-ai/pr-agent) - AI-powered tool for automated PR analysis, feedback, suggestions, and more.
-- [MutableAI](https://mutable.ai/) - AI Accelerated Software Development.
-- [TurboPilot](https://github.com/ravenscroftj/turbopilot) - A self-hosted copilot clone that uses the library behind llama.cpp to run the 6 billion parameter Salesforce Codegen model in 4 GB of RAM.
-- [GPT-Code UI](https://github.com/ricklamers/gpt-code-ui) - An open-source implementation of OpenAI's ChatGPT Code interpreter.
-- [MetaGPT](https://github.com/geekan/MetaGPT) - The Multi-Agent Framework: Given one line Requirement, return PRD, Design, Tasks, Repo
-- [MutahunterAI](https://github.com/codeintegrity-ai/mutahunter) - Accelerate developer productivity and code security with our open-source AI.
-- [AI Kernel Explorer](https://github.com/mathiscode/ai-kernel-explorer) - Explore the Linux kernel source code with AI-generated summaries.
-- [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
-- [FlexApp](https://flexapp.ai/) - Build mobile apps with AI, not code
-- [Kilo Code](https://kilocode.ai) - Open Source AI coding assistant for planning, building, and fixing code inside VS Code.
-- [Capacity](https://capacity.so) - Capacity lets you turn your ideas into fully functional web apps in minutes using AI.
-- [Runcell](https://runcell.dev) - AI Agent Extension for Jupyter Lab, Agent that can code, execute, analysis cell result, etc in Jupyter.
-- [Manifest](https://github.com/mnfst/manifest) - An alternative to Supabase for AI Code editors and Vibe Coding tools
-- [DataPup](https://github.com/DataPupOrg/DataPup) - Database client with AI-powered query assistance to generate context based queries.
-- [Gito](https://github.com/Nayjest/Gito) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
+- <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?🍴</code></b> [GitHub Copilot](https://github.com/features/copilot)) - GitHub Copilot uses the OpenAI Codex to suggest code and entire functions in real-time, right from your editor.
+- <b><code>&nbsp;&nbsp;&nbsp;&nbsp;58⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4🍴</code></b> [poorcoder](https://github.com/vgrichina/poorcoder)) - Lightweight Bash scripts that enhance your terminal coding workflow with web-based AI assistants like Claude or Grok without disrupting your development process.
+- 🌎 [OpenAI Codex](platform.openai.com/docs/guides/code/) - An AI system by OpenAI that translates natural language to code.
+- 🌎 [Ghostwriter](blog.replit.com/ai) - An AI-powered pair programmer by Replit.
+- 🌎 [GoCodeo](www.gocodeo.com/)- An AI Coding & Testing Agent.
+- [Amazon Q Developer] 🌎 [https://aws.amazon.com/codewhisperer/](aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el)) - AI coding assistant with extensions for IDEs such as VS Code and IntelliJ IDEA that provides both chat and agentic workflows.
+- 🌎 [Amazon CodeWhisperer](aws.amazon.com/codewhisperer/) - Build applications faster with the ML-powered coding companion.
+- 🌎 [tabnine](www.tabnine.com/) - Code faster with whole-line & full-function code completions.
+- 🌎 [Stenography](stenography.dev/) - Automatic code documentation.
+- 🌎 [Mintlify](mintlify.com/) - AI powered documentation writer.
+- 🌎 [Debuild](debuild.app/) - AI-powered low-code tool for web apps.
+- 🌎 [AI2sql](www.ai2sql.io/) - With AI2sql, engineers and non-engineers can easily write efficient, error-free SQL queries without knowing SQL.
+- 🌎 [CodiumAI](www.codium.ai/) - With CodiumAI, you get non-trivial tests suggested right inside your IDE, so you stay confident when you push.
+- <b><code>&nbsp;12817⭐</code></b> <b><code>&nbsp;&nbsp;1793🍴</code></b> [PR-Agent](https://github.com/Codium-ai/pr-agent)) - AI-powered tool for automated PR analysis, feedback, suggestions, and more.
+- 🌎 [MutableAI](mutable.ai/) - AI Accelerated Software Development.
+- <b><code>&nbsp;&nbsp;3777⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;121🍴</code></b> [TurboPilot](https://github.com/ravenscroftj/turbopilot)) - A self-hosted copilot clone that uses the library behind llama.cpp to run the 6 billion parameter Salesforce Codegen model in 4 GB of RAM.
+- <b><code>&nbsp;&nbsp;3537⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;426🍴</code></b> [GPT-Code UI](https://github.com/ricklamers/gpt-code-ui)) - An open-source implementation of OpenAI's ChatGPT Code interpreter.
+- <b><code>&nbsp;70168⭐</code></b> <b><code>&nbsp;&nbsp;8922🍴</code></b> [MetaGPT](https://github.com/geekan/MetaGPT)) - The Multi-Agent Framework: Given one line Requirement, return PRD, Design, Tasks, Repo
+- <b><code>&nbsp;&nbsp;&nbsp;300⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;26🍴</code></b> [MutahunterAI](https://github.com/codeintegrity-ai/mutahunter)) - Accelerate developer productivity and code security with our open-source AI.
+- <b><code>&nbsp;&nbsp;&nbsp;&nbsp;32⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3🍴</code></b> [AI Kernel Explorer](https://github.com/mathiscode/ai-kernel-explorer)) - Explore the Linux kernel source code with AI-generated summaries.
+- <b><code>&nbsp;&nbsp;5018⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;238🍴</code></b> [WhoDB](https://github.com/clidey/whodb)) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
+- 🌎 [FlexApp](flexapp.ai/) - Build mobile apps with AI, not code
+- 🌎 [Kilo Code](kilocode.ai) - Open Source AI coding assistant for planning, building, and fixing code inside VS Code.
+- 🌎 [Capacity](capacity.so) - Capacity lets you turn your ideas into fully functional web apps in minutes using AI.
+- 🌎 [Runcell](runcell.dev) - AI Agent Extension for Jupyter Lab, Agent that can code, execute, analysis cell result, etc in Jupyter.
+- <b><code>&nbsp;&nbsp;7499⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;507🍴</code></b> [Manifest](https://github.com/mnfst/manifest)) - An alternative to Supabase for AI Code editors and Vibe Coding tools
+- <b><code>&nbsp;&nbsp;&nbsp;309⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;44🍴</code></b> [DataPup](https://github.com/DataPupOrg/DataPup)) - Database client with AI-powered query assistance to generate context based queries.
+- <b><code>&nbsp;&nbsp;&nbsp;432⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;39🍴</code></b> [Gito](https://github.com/Nayjest/Gito)) - AI code reviewer for GitHub Actions or local use, compatible with any LLM and integrated with Jira/Linear.
 
 
 ## Image
 
-*For a more complete list of AI Image tools visit: [Best Image AI Tools](https://github.com/mahseema/awesome-ai-tools/blob/main/IMAGE.md) or [Awesome AI Image](https://github.com/xaramore/awesome-ai-image)*
+*For a more complete list of AI Image tools visit: [Best Image AI Tools](https://github.com/correia-jpv/fucking-awesome-ai-tools/blob/main/IMAGE.md) or <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?🍴</code></b> [Awesome AI Image](https://github.com/xaramore/awesome-ai-image))*
 
 
 ### Models
 
-- [DALL·E 2](https://openai.com/dall-e-2/) - DALL·E 2 by OpenAI is a new AI system that can create realistic images and art from a description in natural language.
-- [Stable Diffusion](https://huggingface.co/CompVis/stable-diffusion-v1-4) - Stable Diffusion by Stability AI is a state-of-the-art text-to-image model that generates images from text. #opensource
-- [Midjourney](https://www.midjourney.com/) - Midjourney is an independent research lab exploring new mediums of thought and expanding the imaginative powers of the human species.
-- [Imagen](https://imagen.research.google/) - Imagen by Google is a text-to-image diffusion model with an unprecedented degree of photorealism and a deep level of language understanding.
-- [Make-A-Scene](https://ai.facebook.com/blog/greater-creative-control-for-ai-image-generation/) - Make-A-Scene by Meta is a multimodal generative AI method puts creative control in the hands of people who use it by allowing them to describe and illustrate their vision through both text descriptions and freeform sketches.
-- [DragGAN](https://github.com/XingangPan/DragGAN) - Drag Your GAN: Interactive Point-based Manipulation on the Generative Image Manifold.
-- [Canva](https://www.canva.com/) - Generate and Edit your Pictures with the help of AI
+- 🌎 [DALL·E 2](openai.com/dall-e-2/) - DALL·E 2 by OpenAI is a new AI system that can create realistic images and art from a description in natural language.
+- 🌎 [Stable Diffusion](huggingface.co/CompVis/stable-diffusion-v1-4) - Stable Diffusion by Stability AI is a state-of-the-art text-to-image model that generates images from text. #opensource
+- 🌎 [Midjourney](www.midjourney.com/) - Midjourney is an independent research lab exploring new mediums of thought and expanding the imaginative powers of the human species.
+- 🌎 [Imagen](imagen.research.google/) - Imagen by Google is a text-to-image diffusion model with an unprecedented degree of photorealism and a deep level of language understanding.
+- 🌎 [Make-A-Scene](ai.facebook.com/blog/greater-creative-control-for-ai-image-generation/) - Make-A-Scene by Meta is a multimodal generative AI method puts creative control in the hands of people who use it by allowing them to describe and illustrate their vision through both text descriptions and freeform sketches.
+- <b><code>&nbsp;35749⭐</code></b> <b><code>&nbsp;&nbsp;3400🍴</code></b> [DragGAN](https://github.com/XingangPan/DragGAN)) - Drag Your GAN: Interactive Point-based Manipulation on the Generative Image Manifold.
+- 🌎 [Canva](www.canva.com/) - Generate and Edit your Pictures with the help of AI
 
 ### Services
 
-- [Craiyon](https://www.craiyon.com/) - Craiyon, formerly DALL-E mini, is an AI model that can draw images from any text prompt.
-- [DreamStudio](https://beta.dreamstudio.ai/) - DreamStudio is an easy-to-use interface for creating images using the Stable Diffusion image generation model.
-- [Artbreeder](https://www.artbreeder.com/) - Artbreeder is a new type of creative tool that empowers users creativity by making it easier to collaborate and explore.
+- 🌎 [Craiyon](www.craiyon.com/) - Craiyon, formerly DALL-E mini, is an AI model that can draw images from any text prompt.
+- 🌎 [DreamStudio](beta.dreamstudio.ai/) - DreamStudio is an easy-to-use interface for creating images using the Stable Diffusion image generation model.
+- 🌎 [Artbreeder](www.artbreeder.com/) - Artbreeder is a new type of creative tool that empowers users creativity by making it easier to collaborate and explore.
 - [GauGAN2](http://gaugan.org/gaugan2/) - GauGAN2 is a robust tool for creating photorealistic art using a combination of words and drawings since it integrates segmentation mapping, inpainting, and text-to-image production in a single model.
-- [Magic Eraser](https://www.magiceraser.io/) - Remove unwanted things from images in seconds.
-- [Imagine by Magic Studio](https://magicstudio.com/imagine) - A tool by Magic Studio that let's you express yourself by just describing what's on your mind.
-- [Alpaca](https://www.getalpaca.io/) - Stable Diffusion Photoshop plugin.
-- [Patience.ai](https://www.patience.ai/) - Patience.ai is an app for creating images with Stable Diffusion, a cutting-edge AI developed by Stability.AI.
-- [GenShare](https://www.genshare.io/) - Generate art in seconds for free. Own and share what you create. A multimedia generative studio, democratizing design and creativity.
-- [Playground AI](https://playgroundai.com/) - Playground AI is a free-to-use online AI image creator. Use it to create art, social media posts, presentations, posters, videos, logos and more.
-- [Pixelz AI Art Generator](https://pixelz.ai/) - Pixelz AI Art Generator enables you to create incredible art from text. Stable Diffusion, CLIP Guided Diffusion & PXL·E realistic algorithms available.
-- [modyfi](https://www.modyfi.io/) - The image editor you've always wanted. AI-powered creative tools in your browser. Real-time collaboration.
-- [Ponzu](https://www.ponzu.ai/) - Ponzu is your free AI logo generator. Build your brand with creatively designed logos in seconds, using only your imagination.
-- [PhotoRoom](https://www.photoroom.com/) - Create product and portrait pictures using only your phone. Remove background, change background and showcase products.
-- [PhotoGuruAI](https://photoguruai.com/) - Create professional AI Headshots in various styles.
-- [Avatar AI](https://avatarai.me/) - Create your own AI-generated avatars.
-- [ClipDrop](https://clipdrop.co/) - Create professional visuals without a photo studio, powered by [stability.ai](https://stability.ai/).
-- [Lensa](https://prisma-ai.com/lensa) - An all-in-one image editing app that includes the generation of personalized avatars using Stable Diffusion.
-- [RunDiffusion](https://rundiffusion.com/) - Cloud-based workspace for creating AI-generated art.
-- [Human Generator](https://generated.photos/human-generator) - AI generator or realistic looking photos of humans.
-- [VectorArt.ai](https://vectorart.ai) - Create vector images with AI.
-- [StockPhotoAI.net](https://www.stockphotoai.net/?ref=mahseema-awesome-ai-tools) - Great stock photos, made for you.
-- [Room Reinvented](https://roomreinvented.com) - Transform your room effortlessly with Room Reinvented! Upload a photo and let AI create over 30 stunning interior styles. Elevate your space today.
-- [Gensbot](https://gensbot.com) - Gensbot uses AI to craft personalised printed merchandise. One prompt creates one unique product to fit your needs.
-- [PlantPhotoAI](https://www.plantphotoai.com/) - free AI-generated plant images
-- [RepublicLabs.AI](https://republiclabs.ai/) - multi-model simultaneous generation from a single prompt, fully unrestricted and packed with the latest greatest AI models.
-- [Black Headshots](https://www.blackheadshots.com) - AI headshots generator for black professionals
-- [Pixvify AI](https://pixvify.com/) - Free realistic AI photo generator platform
-- [Pawtrait](https://www.pawtrait.art/) - AI Pet Portraits
-- [iColoring](https://icoloring.ai) - Free AI Coloring Pages Generator
-- [Suit me Up](https://suitmeup.pictures/) - Generate pictures of you wearing a suit with AI.
-- [AI Photo Forge](https://aiphotoforge.com/) - A Telegram bot to generate AI pictures of you.
-- [AI Boost](https://boost.pictures/) - All-in-one service for creating and editing images with AI: upscale images, swap faces, generate new visuals and avatars, try on outfits, reshape body contours, change backgrounds, retouch faces, and even test out tattoos.
-- [PlantTattoosAI](https://www.planttattoosai.com/) - Plant and flower tattoos designs generator trained on real botanicals.
+- 🌎 [Magic Eraser](www.magiceraser.io/) - Remove unwanted things from images in seconds.
+- 🌎 [Imagine by Magic Studio](magicstudio.com/imagine) - A tool by Magic Studio that let's you express yourself by just describing what's on your mind.
+- 🌎 [Alpaca](www.getalpaca.io/) - Stable Diffusion Photoshop plugin.
+- 🌎 [Patience.ai](www.patience.ai/) - Patience.ai is an app for creating images with Stable Diffusion, a cutting-edge AI developed by Stability.AI.
+- 🌎 [GenShare](www.genshare.io/) - Generate art in seconds for free. Own and share what you create. A multimedia generative studio, democratizing design and creativity.
+- 🌎 [Playground AI](playgroundai.com/) - Playground AI is a free-to-use online AI image creator. Use it to create art, social media posts, presentations, posters, videos, logos and more.
+- 🌎 [Pixelz AI Art Generator](pixelz.ai/) - Pixelz AI Art Generator enables you to create incredible art from text. Stable Diffusion, CLIP Guided Diffusion & PXL·E realistic algorithms available.
+- 🌎 [modyfi](www.modyfi.io/) - The image editor you've always wanted. AI-powered creative tools in your browser. Real-time collaboration.
+- 🌎 [Ponzu](www.ponzu.ai/) - Ponzu is your free AI logo generator. Build your brand with creatively designed logos in seconds, using only your imagination.
+- 🌎 [PhotoRoom](www.photoroom.com/) - Create product and portrait pictures using only your phone. Remove background, change background and showcase products.
+- 🌎 [PhotoGuruAI](photoguruai.com/) - Create professional AI Headshots in various styles.
+- 🌎 [Avatar AI](avatarai.me/) - Create your own AI-generated avatars.
+- 🌎 [ClipDrop](clipdrop.co/) - Create professional visuals without a photo studio, powered by 🌎 [stability.ai](stability.ai/).
+- 🌎 [Lensa](prisma-ai.com/lensa) - An all-in-one image editing app that includes the generation of personalized avatars using Stable Diffusion.
+- 🌎 [RunDiffusion](rundiffusion.com/) - Cloud-based workspace for creating AI-generated art.
+- 🌎 [Human Generator](generated.photos/human-generator) - AI generator or realistic looking photos of humans.
+- 🌎 [VectorArt.ai](vectorart.ai) - Create vector images with AI.
+- 🌎 [StockPhotoAI.net](www.stockphotoai.net/?ref=mahseema-awesome-ai-tools) - Great stock photos, made for you.
+- 🌎 [Room Reinvented](roomreinvented.com) - Transform your room effortlessly with Room Reinvented! Upload a photo and let AI create over 30 stunning interior styles. Elevate your space today.
+- 🌎 [Gensbot](gensbot.com) - Gensbot uses AI to craft personalised printed merchandise. One prompt creates one unique product to fit your needs.
+- 🌎 [PlantPhotoAI](www.plantphotoai.com/) - free AI-generated plant images
+- 🌎 [RepublicLabs.AI](republiclabs.ai/) - multi-model simultaneous generation from a single prompt, fully unrestricted and packed with the latest greatest AI models.
+- 🌎 [Black Headshots](www.blackheadshots.com) - AI headshots generator for black professionals
+- 🌎 [Pixvify AI](pixvify.com/) - Free realistic AI photo generator platform
+- 🌎 [Pawtrait](www.pawtrait.art/) - AI Pet Portraits
+- 🌎 [iColoring](icoloring.ai) - Free AI Coloring Pages Generator
+- 🌎 [Suit me Up](suitmeup.pictures/) - Generate pictures of you wearing a suit with AI.
+- 🌎 [AI Photo Forge](aiphotoforge.com/) - A Telegram bot to generate AI pictures of you.
+- 🌎 [AI Boost](boost.pictures/) - All-in-one service for creating and editing images with AI: upscale images, swap faces, generate new visuals and avatars, try on outfits, reshape body contours, change backgrounds, retouch faces, and even test out tattoos.
+- 🌎 [PlantTattoosAI](www.planttattoosai.com/) - Plant and flower tattoos designs generator trained on real botanicals.
 
 
 
 ### Graphic design
 
-- [Brandmark](https://brandmark.io/) - AI-based logo design tool.
-- [Gamma](https://gamma.app/) - Create beautiful presentations and webpages with none of the formatting and design work.
-- [Microsoft Designer](https://designer.microsoft.com/) - Stunning designs in a flash.
-- [SVGStud.io](https://svgstud.io/) - AI-based SVG Generation and Semantic Seach
-- [Text2Infographic](https://text2infographic.com/) - AI infographic generator and editor.
-- [Seede.ai](https://seede.ai/) - Create a stunning poster in just 1 minute with Seede.
-- [Magic Patterns](https://www.magicpatterns.com/) - AI-based UI builder with Figma export and React code generation.
+- 🌎 [Brandmark](brandmark.io/) - AI-based logo design tool.
+- 🌎 [Gamma](gamma.app/) - Create beautiful presentations and webpages with none of the formatting and design work.
+- 🌎 [Microsoft Designer](designer.microsoft.com/) - Stunning designs in a flash.
+- 🌎 [SVGStud.io](svgstud.io/) - AI-based SVG Generation and Semantic Seach
+- 🌎 [Text2Infographic](text2infographic.com/) - AI infographic generator and editor.
+- 🌎 [Seede.ai](seede.ai/) - Create a stunning poster in just 1 minute with Seede.
+- 🌎 [Magic Patterns](www.magicpatterns.com/) - AI-based UI builder with Figma export and React code generation.
 
 
 ### Image libraries
 
-- [Lexica](https://lexica.art/) - Stable Diffusion search engine.
-- [Libraire](https://libraire.ai/) - The largest library of AI-generated images.
-- [KREA](https://www.krea.ai/) - Explore millions of AI-generated images and create collections of prompts. Featuring Stable Diffusion generations.
-- [OpenArt](https://openart.ai/) - Search 10M+ of prompts, and generate AI art via Stable Diffusion, DALL·E 2.
-- [Phygital](https://app.phygital.plus/) - Built-in templates for generating or editing any pictures. Moreover, you can create your own design.
-- [Canva](https://www.canva.com/ai-image-generator/) - Generating AI Images.
+- 🌎 [Lexica](lexica.art/) - Stable Diffusion search engine.
+- 🌎 [Libraire](libraire.ai/) - The largest library of AI-generated images.
+- 🌎 [KREA](www.krea.ai/) - Explore millions of AI-generated images and create collections of prompts. Featuring Stable Diffusion generations.
+- 🌎 [OpenArt](openart.ai/) - Search 10M+ of prompts, and generate AI art via Stable Diffusion, DALL·E 2.
+- 🌎 [Phygital](app.phygital.plus/) - Built-in templates for generating or editing any pictures. Moreover, you can create your own design.
+- 🌎 [Canva](www.canva.com/ai-image-generator/) - Generating AI Images.
 
 ### Model libraries
 
-- [Civitai](https://civitai.com/) - Community-driven AI model sharing tool.
-- [Stable Diffusion Models](https://rentry.org/sdmodels) - A comprehensive list of Stable Diffusion checkpoints on rentry.org.
+- 🌎 [Civitai](civitai.com/) - Community-driven AI model sharing tool.
+- 🌎 [Stable Diffusion Models](rentry.org/sdmodels) - A comprehensive list of Stable Diffusion checkpoints on rentry.org.
 
 ### Stable Diffusion resources
 
-- [Stable Horde](https://stablehorde.net/) - A crowdsourced distributed cluster of Stable Diffusion workers.
-- [PublicPrompts](https://publicprompts.art/) - A collection of free prompts for Stable Diffusion.
-- [Hugging Face Diffusion Models Course](https://github.com/huggingface/diffusion-models-class) - Python materials for the online course on diffusion models by [@huggingface](https://github.com/huggingface).
+- 🌎 [Stable Horde](stablehorde.net/) - A crowdsourced distributed cluster of Stable Diffusion workers.
+- 🌎 [PublicPrompts](publicprompts.art/) - A collection of free prompts for Stable Diffusion.
+- <b><code>&nbsp;&nbsp;4357⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;496🍴</code></b> [Hugging Face Diffusion Models Course](https://github.com/huggingface/diffusion-models-class)) - Python materials for the online course on diffusion models by [@huggingface](https://github.com/huggingface).
 
 ## Video
 
-- [RunwayML](https://runwayml.com/) - Magical AI tools, realtime collaboration, precision editing, and more. Your next-generation content creation suite.
-- [Synthesia](https://www.synthesia.io/) - Create videos from plain text in minutes.
-- [Rephrase AI](https://www.rephrase.ai/) - Rephrase's technology enables hyper-personalized video creation at scale that drive engagement and business efficiencies.
-- [Hour One](https://hourone.ai/) - Turn text into video, featuring virtual presenters, automatically.
-- [D-ID](https://www.d-id.com/) - Create and interact with talking avatars at the touch of a button.
-- [ShortVideoGen](https://shortgen.video/) - Create short videos with audio using text prompts.
-- [Clipwing](https://clipwing.pro/) - A tool for cutting long videos into dozens of short clips.
-- [Recast Studio](https://recast.studio) - AI powered podcast marketing assistant.
-- [Based AI](https://www.basedlabs.ai/) - AI Intuitive Interface for Video creating
-- [klingai](https://app.klingai.com/global/) - AI creative studio boasts AI image and video generation capabilities.
-- [Sisif](https://sisif.ai/) - AI Video Generator: Turn Text into Stunning Videos in Seconds
+- 🌎 [RunwayML](runwayml.com/) - Magical AI tools, realtime collaboration, precision editing, and more. Your next-generation content creation suite.
+- 🌎 [Synthesia](www.synthesia.io/) - Create videos from plain text in minutes.
+- 🌎 [Rephrase AI](www.rephrase.ai/) - Rephrase's technology enables hyper-personalized video creation at scale that drive engagement and business efficiencies.
+- 🌎 [Hour One](hourone.ai/) - Turn text into video, featuring virtual presenters, automatically.
+- 🌎 [D-ID](www.d-id.com/) - Create and interact with talking avatars at the touch of a button.
+- 🌎 [ShortVideoGen](shortgen.video/) - Create short videos with audio using text prompts.
+- 🌎 [Clipwing](clipwing.pro/) - A tool for cutting long videos into dozens of short clips.
+- 🌎 [Recast Studio](recast.studio) - AI powered podcast marketing assistant.
+- 🌎 [Based AI](www.basedlabs.ai/) - AI Intuitive Interface for Video creating
+- 🌎 [klingai](app.klingai.com/global/) - AI creative studio boasts AI image and video generation capabilities.
+- 🌎 [Sisif](sisif.ai/) - AI Video Generator: Turn Text into Stunning Videos in Seconds
 
 
 ### Animation
@@ -410,185 +410,188 @@ We publish regular updates of this repo in the [Altern Newsletter](http://newsle
 
 ### AI Voice Cloning
 
-*You can also find more comprehensive list on [Awesome AI Music](https://github.com/xaramore/awesome-ai-music) and [There's an AI AI Voice Cloning list](https://theresanai.com/category/voice-cloning)*
+*You can also find more comprehensive list on <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;?🍴</code></b> [Awesome AI Music](https://github.com/xaramore/awesome-ai-music)) and 🌎 [There's an AI AI Voice Cloning list](theresanai.com/category/voice-cloning)*
 
-- [Descript Overdub](https://www.descript.com/overdub) - [Review](https://theresanai.com/descript-overdub) - Seamlessly integrates with Descript’s transcription and editing tools, ideal for content creators needing quick voiceovers.
-- [Respeecher](https://www.respeecher.com/) - [Review](https://theresanai.com/respeecher) -  A professional tool widely used in the entertainment industry to create emotion-rich, realistic voice clones.
-- [ElevenLabs](https://elevenlabs.io/) - [Review](https://theresanai.com/elevenlabs) - Known for ultra-realistic voice cloning and emotion modeling, setting a new standard in AI-driven voice synthesis.
-- [Resemble AI](https://www.resemble.ai/) - [Review](https://theresanai.com/resemble-ai) - Offers real-time voice synthesis with customization options, making it versatile for both developers and creatives.
-- [Murf AI](https://murf.ai/) - [Review](https://theresanai.com/murf) - User-friendly platform for quick, high-quality voiceovers, favored for commercial and marketing applications.
-- [iSpeech](https://www.ispeech.org/) - [Review](https://theresanai.com/ispeech) - A versatile solution for corporate applications with support for a wide array of languages and voices.
-- [Veritone Voice](https://www.veritone.com/solutions/voice/) - [Review](https://theresanai.com/veritone-voice) - Focuses on maintaining brand consistency with highly customizable voice cloning used in media and entertainment.
-- [Microsoft Azure Neural TTS](https://azure.microsoft.com/en-us/services/cognitive-services/text-to-speech/) - Review - Scalable and highly customizable, ideal for integration into enterprise applications.
-- [WellSaid Labs](https://www.wellsaidlabs.com/) - [Review](https://theresanai.com/wellsaid-labs) - Gaining traction for its natural-sounding voiceovers, particularly in corporate training and e-learning.
-- [Lovo.ai](https://www.lovo.ai/) - [Review](https://theresanai.com/lovo-ai) - A compelling choice for creative professionals, especially useful in ads and explainer videos.
-- [Zenmic.com](https://zenmic.com) -  An app to generate podcast eposode ( script + Audio ) using AI.
-- [Audify AI](https://audify-ai.ahmedtokyo.com) - User-friendly platform for voice synthesis with customizable options and instructions, making it versatile for both developers and creatives.
-- [TTS WebUI](https://github.com/rsxdalv/tts-generation-webui) - Open Source generative AI App for voice and music, supporting 15+ TTS models.
-- [AInterview.space](https://ainterview.space) – Create AI-hosted podcast interviews. Choose a topic, and Joe (the AI host) will research, host the interview, and generate your episode as audio or video.
+- 🌎 [Descript Overdub](www.descript.com/overdub) - 🌎 [Review](theresanai.com/descript-overdub) - Seamlessly integrates with Descript’s transcription and editing tools, ideal for content creators needing quick voiceovers.
+- 🌎 [Respeecher](www.respeecher.com/) - 🌎 [Review](theresanai.com/respeecher) -  A professional tool widely used in the entertainment industry to create emotion-rich, realistic voice clones.
+- 🌎 [ElevenLabs](elevenlabs.io/) - 🌎 [Review](theresanai.com/elevenlabs) - Known for ultra-realistic voice cloning and emotion modeling, setting a new standard in AI-driven voice synthesis.
+- 🌎 [Resemble AI](www.resemble.ai/) - 🌎 [Review](theresanai.com/resemble-ai) - Offers real-time voice synthesis with customization options, making it versatile for both developers and creatives.
+- 🌎 [Murf AI](murf.ai/) - 🌎 [Review](theresanai.com/murf) - User-friendly platform for quick, high-quality voiceovers, favored for commercial and marketing applications.
+- 🌎 [iSpeech](www.ispeech.org/) - 🌎 [Review](theresanai.com/ispeech) - A versatile solution for corporate applications with support for a wide array of languages and voices.
+- 🌎 [Veritone Voice](www.veritone.com/solutions/voice/) - 🌎 [Review](theresanai.com/veritone-voice) - Focuses on maintaining brand consistency with highly customizable voice cloning used in media and entertainment.
+- 🌎 [Microsoft Azure Neural TTS](azure.microsoft.com/en-us/services/cognitive-services/text-to-speech/) - Review - Scalable and highly customizable, ideal for integration into enterprise applications.
+- 🌎 [WellSaid Labs](www.wellsaidlabs.com/) - 🌎 [Review](theresanai.com/wellsaid-labs) - Gaining traction for its natural-sounding voiceovers, particularly in corporate training and e-learning.
+- 🌎 [Lovo.ai](www.lovo.ai/) - 🌎 [Review](theresanai.com/lovo-ai) - A compelling choice for creative professionals, especially useful in ads and explainer videos.
+- 🌎 [Zenmic.com](zenmic.com) -  An app to generate podcast eposode ( script + Audio ) using AI.
+- 🌎 [Audify AI](audify-ai.ahmedtokyo.com) - User-friendly platform for voice synthesis with customizable options and instructions, making it versatile for both developers and creatives.
+- <b><code>&nbsp;&nbsp;3250⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;329🍴</code></b> [TTS WebUI](https://github.com/rsxdalv/tts-generation-webui)) - Open Source generative AI App for voice and music, supporting 15+ TTS models.
+- 🌎 [AInterview.space](ainterview.space) – Create AI-hosted podcast interviews. Choose a topic, and Joe (the AI host) will research, host the interview, and generate your episode as audio or video.
 
 
 ### AI Music Generators
 
-*You can also find  more comprehensive list on [There's an AI AI Music Generation Tools list](https://theresanai.com/category/music-generation)*
+*You can also find  more comprehensive list on 🌎 [There's an AI AI Music Generation Tools list](theresanai.com/category/music-generation)*
 
 
-- [Splash Pro](https://www.splashpro.com) - [Review](https://theresanai.com/splash-pro) - A versatile platform offering intuitive music creation tools for all skill levels.
-- [AIVA](https://www.aiva.ai) - [Review](https://theresanai.com/aiva) - AI composer specializing in classical and cinematic music creation.
-- [Mubert](https://www.mubert.com) - [Review](https://theresanai.com/mubert) - Real-time generative music tailored for different use cases.
-- [Soundraw](https://soundraw.io) - [Review](https://theresanai.com/soundraw) - Allows users to customize music compositions based on mood and style.
-- [Beatoven.ai](https://www.beatoven.ai) - [Review](https://theresanai.com/beatoven-ai) - AI-driven music generation focused on evoking specific emotions.
-- [Boomy](https://www.boomy.com) - [Review](https://theresanai.com/boomy) - Democratizes music creation with quick track generation and monetization.
-- [Ecrett Music](https://www.ecrettmusic.com) - [Review](https://theresanai.com/ecrett-music) - Designed for video creators, offering royalty-free music.
-- [Loudly](https://www.loudly.com) - [Review](https://theresanai.com/loudly) - Combines AI music generation with a social platform for collaboration.
-- [Soundful](https://www.soundful.com) - [Review](https://theresanai.com/soundful) - High-quality, royalty-free music for content creators.
-- [AI Music Generator](https://www.aisongmaker.io) - [Review](https://www.producthunt.com/products/ai-song-maker) - Effortlessly Create Songs with AI
+- 🌎 [Splash Pro](www.splashpro.com) - 🌎 [Review](theresanai.com/splash-pro) - A versatile platform offering intuitive music creation tools for all skill levels.
+- 🌎 [AIVA](www.aiva.ai) - 🌎 [Review](theresanai.com/aiva) - AI composer specializing in classical and cinematic music creation.
+- 🌎 [Mubert](www.mubert.com) - 🌎 [Review](theresanai.com/mubert) - Real-time generative music tailored for different use cases.
+- 🌎 [Soundraw](soundraw.io) - 🌎 [Review](theresanai.com/soundraw) - Allows users to customize music compositions based on mood and style.
+- 🌎 [Beatoven.ai](www.beatoven.ai) - 🌎 [Review](theresanai.com/beatoven-ai) - AI-driven music generation focused on evoking specific emotions.
+- 🌎 [Boomy](www.boomy.com) - 🌎 [Review](theresanai.com/boomy) - Democratizes music creation with quick track generation and monetization.
+- 🌎 [Ecrett Music](www.ecrettmusic.com) - 🌎 [Review](theresanai.com/ecrett-music) - Designed for video creators, offering royalty-free music.
+- 🌎 [Loudly](www.loudly.com) - 🌎 [Review](theresanai.com/loudly) - Combines AI music generation with a social platform for collaboration.
+- 🌎 [Soundful](www.soundful.com) - 🌎 [Review](theresanai.com/soundful) - High-quality, royalty-free music for content creators.
+- 🌎 [AI Music Generator](www.aisongmaker.io) - 🌎 [Review](www.producthunt.com/products/ai-song-maker) - Effortlessly Create Songs with AI
 
 
 ### Marketing AI Tools
 
-*You can also find  more comprehensive list on *[Marketing List](https://github.com/mahseema/awesome-ai-tools/blob/main/marketing.md)*
+*You can also find  more comprehensive list on *[Marketing List](https://github.com/correia-jpv/fucking-awesome-ai-tools/blob/main/marketing.md)*
 
-- **[Jasper AI](https://www.jasper.ai/)** - AI-powered tool for generating marketing content like blogs, emails, and ad copy.
-- **[Mutiny](https://www.mutinyhq.com/)** - Personalization platform to improve website conversions using AI.
-- **[Clearbit](https://clearbit.com/)** - Lead enrichment and data intelligence platform.
-- **[Seventh Sense](https://www.theseventhsense.com/)** - AI tool for email send time optimization.
-- **[Smartly.io](https://www.smartly.io/)** - Automates social media ad creation and optimization.
-- **[Adzooma](https://www.adzooma.com/)** - AI-powered PPC campaign management platform.
-- **[Phrasee](https://www.phrasee.co/)** - AI tool that generates optimized marketing copy.
-- **[Crimson Hexagon](https://www.crimsonhexagon.com/)** - AI-based social media sentiment analysis platform.
-- **[MarketMuse](https://www.marketmuse.com/)** - SEO content optimization platform using AI.
-- **[Chatfuel](https://www.chatfuel.com/)** - AI-driven chatbot for automating customer engagement on Messenger.
-- **[LogicBalls](https://logicballs.com/)** - An AI-powered writing tool to create any type of content and supercharge your productivity.
-- **[Rupert AI](https://www.getrupert.com/)** - AI tools for designers and marketers
-- **[PersonaForce](https://personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
-- **[Publish7](https://publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
-- **[Keyla.AI](https://keyla.ai/)** - Create video ads in minutes
+- * 🌎 [Jasper AI](www.jasper.ai/)** - AI-powered tool for generating marketing content like blogs, emails, and ad copy.
+- * 🌎 [Mutiny](www.mutinyhq.com/)** - Personalization platform to improve website conversions using AI.
+- * 🌎 [Clearbit](clearbit.com/)** - Lead enrichment and data intelligence platform.
+- * 🌎 [Seventh Sense](www.theseventhsense.com/)** - AI tool for email send time optimization.
+- * 🌎 [Smartly.io](www.smartly.io/)** - Automates social media ad creation and optimization.
+- * 🌎 [Adzooma](www.adzooma.com/)** - AI-powered PPC campaign management platform.
+- * 🌎 [Phrasee](www.phrasee.co/)** - AI tool that generates optimized marketing copy.
+- * 🌎 [Crimson Hexagon](www.crimsonhexagon.com/)** - AI-based social media sentiment analysis platform.
+- * 🌎 [MarketMuse](www.marketmuse.com/)** - SEO content optimization platform using AI.
+- * 🌎 [Chatfuel](www.chatfuel.com/)** - AI-driven chatbot for automating customer engagement on Messenger.
+- * 🌎 [LogicBalls](logicballs.com/)** - An AI-powered writing tool to create any type of content and supercharge your productivity.
+- * 🌎 [Rupert AI](www.getrupert.com/)** - AI tools for designers and marketers
+- * 🌎 [PersonaForce](personaforce.ai/)** - Create and chat with AI buyer personas for smarter marketing
+- * 🌎 [Publish7](publish7.com/)** -AI Agents to revolutionize digital marketing for Retail and E-commerce success.
+- * 🌎 [Keyla.AI](keyla.ai/)** - Create video ads in minutes
 
 
 ### Phone Calls
-- [AICaller.io](https://aicaller.io/?ref=v) - AICaller is a simple-to-use automated bulk calling solution that uses the latest Generative AI technology to trigger phone calls for you and get things done. It can do things like lead qualification, data gathering over phone calls, and much more. It comes with a powerful API, low cost pricing and free trial.
-- [AI Voice Agents](https://diallink.com/) — AI Voice Agents for business calls and routine tasks, powered by DialLink cloud phone system.
-- [Cald.ai](https://cald.ai) - AI based calling agents for outbound and inbound phone calls.
-- [Rosie](https://heyrosie.com/) - AI Phone Answering Service
+- 🌎 [AICaller.io](aicaller.io/?ref=v) - AICaller is a simple-to-use automated bulk calling solution that uses the latest Generative AI technology to trigger phone calls for you and get things done. It can do things like lead qualification, data gathering over phone calls, and much more. It comes with a powerful API, low cost pricing and free trial.
+- 🌎 [AI Voice Agents](diallink.com/) — AI Voice Agents for business calls and routine tasks, powered by DialLink cloud phone system.
+- 🌎 [Cald.ai](cald.ai) - AI based calling agents for outbound and inbound phone calls.
+- 🌎 [Rosie](heyrosie.com/) - AI Phone Answering Service
 
 ### Speech
-- [Eleven Labs](https://beta.elevenlabs.io/) - AI voice generator.
-- [Resemble AI](https://www.resemble.ai/) - AI voice generator and voice cloning for text to speech.
-- [WellSaid](https://wellsaidlabs.com/) - Convert text to voice in real time.
-- [Play.ht](https://play.ht/) - AI Voice Generator. Generate realistic Text to Speech voice over online with AI. Convert text to audio.
-- [Coqui](https://coqui.ai/) - Generative AI for Voice.
-- [podcast.ai](https://podcast.ai/) - A podcast that is entirely generated by artificial intelligence, powered by Play.ht text-to-voice AI.
-- [VALL-E X](https://vallex-demo.github.io/) - A cross-lingual neural codec language model for cross-lingual speech synthesis.
-- [TorToiSe](https://github.com/neonbjb/tortoise-tts) - A multi-voice text-to-speech system trained with an emphasis on quality. #opensource
-- [Bark](https://github.com/suno-ai/bark) - A transformer-based text-to-audio model. #opensource
-- [CustomPod.io](https://custompod.io) - Generate daily news podcasts only on the topics you care about.
-- [EKHOS AI](https://ekhos.ai) - An AI speech-to-text software with powerful proofreading features. Transcribe most audio or video files with real-time recording and transcription.
+- 🌎 [Eleven Labs](beta.elevenlabs.io/) - AI voice generator.
+- 🌎 [Resemble AI](www.resemble.ai/) - AI voice generator and voice cloning for text to speech.
+- 🌎 [WellSaid](wellsaidlabs.com/) - Convert text to voice in real time.
+- 🌎 [Play.ht](play.ht/) - AI Voice Generator. Generate realistic Text to Speech voice over online with AI. Convert text to audio.
+- 🌎 [Coqui](coqui.ai/) - Generative AI for Voice.
+- 🌎 [podcast.ai](podcast.ai/) - A podcast that is entirely generated by artificial intelligence, powered by Play.ht text-to-voice AI.
+- 🌎 [VALL-E X](vallex-demo.github.io/) - A cross-lingual neural codec language model for cross-lingual speech synthesis.
+- <b><code>&nbsp;14872⭐</code></b> <b><code>&nbsp;&nbsp;2038🍴</code></b> [TorToiSe](https://github.com/neonbjb/tortoise-tts)) - A multi-voice text-to-speech system trained with an emphasis on quality. #opensource
+- <b><code>&nbsp;39259⭐</code></b> <b><code>&nbsp;&nbsp;4667🍴</code></b> [Bark](https://github.com/suno-ai/bark)) - A transformer-based text-to-audio model. #opensource
+- 🌎 [CustomPod.io](custompod.io) - Generate daily news podcasts only on the topics you care about.
+- 🌎 [EKHOS AI](ekhos.ai) - An AI speech-to-text software with powerful proofreading features. Transcribe most audio or video files with real-time recording and transcription.
   
 ### Music
 
-- [Harmonai](https://www.harmonai.org/) - We are a community-driven organization releasing open-source generative audio tools to make music production more accessible and fun for everyone.
-- [Mubert](https://mubert.com/) - A royalty-free music ecosystem for content creators, brands and developers.
-- [MusicLM](https://google-research.github.io/seanet/musiclm/examples/) - A model by Google Research for generating high-fidelity music from text descriptions.
-- [Remusic](https://remusic.ai/en) - AI Music Generator and Music Learning Platform Online Free.
+- 🌎 [Harmonai](www.harmonai.org/) - We are a community-driven organization releasing open-source generative audio tools to make music production more accessible and fun for everyone.
+- 🌎 [Mubert](mubert.com/) - A royalty-free music ecosystem for content creators, brands and developers.
+- 🌎 [MusicLM](google-research.github.io/seanet/musiclm/examples/) - A model by Google Research for generating high-fidelity music from text descriptions.
+- 🌎 [Remusic](remusic.ai/en) - AI Music Generator and Music Learning Platform Online Free.
 
 ## Other
 
-- [Taranify](https://www.taranify.com) - Using AI, Taranify finds you Spotify playlists, Netflix shows, Books & Foods you'd enjoy when you don't exactly know what you want. 
-- [Diagram](https://diagram.com/) - Magical new ways to design products.
-- [PromptBase](https://promptbase.com/) - A marketplace for buying and selling quality prompts for DALL·E, GPT-3, Midjourney, Stable Diffusion.
-- [This Image Does Not Exist](https://thisimagedoesnotexist.com/) - Test your ability to tell if an image is human or computer generated.
-- [Have I Been Trained?](https://haveibeentrained.com/) - Check if your image has been used to train popular AI art models.
-- [AI Dungeon](https://aidungeon.io/) - A text-based adventure-story game you direct (and star in) while the AI brings it to life.
-- [Clickable](https://www.clickable.so/) - Generate ads in seconds with AI. Beautiful, brand-consistent, and highly converting ads for all marketing channels.
-- [Scale Spellbook](https://scale.com/spellbook) - Build, compare, and deploy large language model apps with Scale Spellbook.
-- [Scenario](https://www.scenario.com/) - AI-generated gaming assets.
-- [Teleprompter](https://github.com/danielgross/teleprompter) - An on-device AI for your meetings that listens to you and makes charismatic quote suggestions.
-- [FinChat](https://finchat.io/) - Using AI, FinChat generates answers to questions about public companies and investors.
-- [Petals](https://github.com/bigscience-workshop/petals) - BitTorrent style platform for running AI models in a distributed way.
-- [Shotstack Workflows](https://shotstack.io/product/workflows/) - No-code, automation workflow tool for building Generative AI media applications.
-- [Aispect](https://aispect.io/?ref=mahseema-awesome-ai-tools) - New way to experience events.
-- [PressPulse AI](https://www.presspulse.ai/?ref=mahseema-awesome-ai-tools) - Get personalized media coverage leads every morning.
-- [GummySearch](https://gummysearch.com/?ref=mahseema-awesome-ai-tools) - AI-based customer research via Reddit. Discover problems to solve, sentiment on current solutions, and people who want to buy your product.
-- [Taplio](https://taplio.com/?ref=mahseema-awesome-ai-tools) - The all-in-one, AI-powered LinkedIn tool.
-- [PromptPal](https://promptpal.net) - Search for prompts and bots, then use them with your favorite AI. All in one place.
-- [FairyTailAI](https://fairytailai.com/) - Personalized bedtime story generator
-- [Myriad](https://www.namepepper.com/free-tools/ai-content-prompt-tool) - Scale your content creation and get the best writing from ChatGPT, Copilot, and other AIs. Build and fine-tune prompts for any kind of content, from long-form to ads and email.
-- [GradGPT](https://www.gradgpt.com/) - AI tools to simplify college applications. Review applications, draft essays, find universities and requirements and more.
-- [Code to Flow](https://codetoflow.com) - Visualize, Analyze, and Understand Your Code flow. Turn Code into Interactive Flowcharts with AI. Simplify Complex Logic Instantly.
-- [AI-Flow](https://ai-flow.net/) - Connect multiple AI models easily.
-- [Architecture Helper](https://architecturehelper.com) - Analyze any building architecture, and generate your own custom styles, in seconds.
-- [VocalReplica](https://vocalreplica.com/) - AI-Powered Vocal and Instrumental Isolation for Your Favorite Tracks
-- [AI Wedding Toast](https://aiweddingtoast.com) - Generate a personalized wedding speech with AI
-- [Interviews Chat](https://www.interviews.chat/) - Your Personal Interview Prep & Copilot
-- [Context Data](https://contextdata.ai/) - Data Processing & ETL infrastructure for Generative AI applications
-- [ezJobs](https://www.getezjobs.com/) - Automated job search and applications
-- [Compass](https://www.getwhys.io/compass) - AI driven answers to SaaS research questions
-- [Adon AI](https://adon-web.awakast.com/en/recruiter/) - CV screening automation and blind CV generator, AI backed ATS
-- [Persuva](https://persuva.ai) - Persuva is the AI-driven platform to create persuasive, high-converting ad copy at scale.
-- [Interview Solver](https://interviewsolver.com) - Ace your live coding interviews with our AI Copilot
-- [Socialsonic](https://socialsonic.com) - AI LinkedIn Coach: Personalized content, trends & scheduling.
-- [Napkin](https://www.napkin.ai/) - Napkin turns your text into visuals so sharing your ideas is quick and effective.
-- [Exam Samurai](https://www.examsamur.ai/) - AI Exam Generator
-- [AI Watermark Remover](https://aiwatermarkremover.io/) - Remove watermarks from images and videos.
-- [AISaver](https://aisaver.io) - Collection of AI Powered Video and Photo Tools
-- [Harbor](https://github.com/av/harbor) - run LLM backends, APIs, frontends, and services with one command
-- [LangMagic](https://easytolearn.io) - Learn languages from native content.
-- [fynk](https://fynk.com/) - AI powered contract management software
-- [LooksMax AI](https://looksmax.ai) - Find out how hot you are using AI
-- [Podify.io](https://podify.io) - Leverage AI and community to grow on LinkedIn
-- [ResumeDive](https://resumedive.com) - A resume boosting service using AI
-- [Luthor](https://luthor.ai/) - Programmatic content marketing at scale
-- [Hyperbrowser](https://hyperbrowser.ai/) - Browser infrastructure and automation for AI Agents and Apps with advanced features like proxies, captcha solving, and session recording.
-- [Bricks](https://www.thebricks.com/) - The AI Spreadsheet We've All Been Waiting For
-- [MindStudio](https://mindstudio.ai/) — Build powerful AI Agents for yourself, your team, or your enterprise. Powerful, easy to use, visual builder—no coding required, but extensible with code if you need it. Over 100 templates for all kinds of business and personal use cases.
-- [Daruy](https://daruy.space/) - Personalized Gift Idea Generator
-- [Promptly](https://searchpromptly.com/) - Discover, create and share powerful prompts
-- [Melies](https://melies.co) - AI Filmmaking software
+- 🌎 [Taranify](www.taranify.com) - Using AI, Taranify finds you Spotify playlists, Netflix shows, Books & Foods you'd enjoy when you don't exactly know what you want. 
+- 🌎 [Diagram](diagram.com/) - Magical new ways to design products.
+- 🌎 [PromptBase](promptbase.com/) - A marketplace for buying and selling quality prompts for DALL·E, GPT-3, Midjourney, Stable Diffusion.
+- 🌎 [This Image Does Not Exist](thisimagedoesnotexist.com/) - Test your ability to tell if an image is human or computer generated.
+- 🌎 [Have I Been Trained?](haveibeentrained.com/) - Check if your image has been used to train popular AI art models.
+- 🌎 [AI Dungeon](aidungeon.io/) - A text-based adventure-story game you direct (and star in) while the AI brings it to life.
+- 🌎 [Clickable](www.clickable.so/) - Generate ads in seconds with AI. Beautiful, brand-consistent, and highly converting ads for all marketing channels.
+- 🌎 [Scale Spellbook](scale.com/spellbook) - Build, compare, and deploy large language model apps with Scale Spellbook.
+- 🌎 [Scenario](www.scenario.com/) - AI-generated gaming assets.
+- <b><code>&nbsp;&nbsp;&nbsp;337⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;38🍴</code></b> [Teleprompter](https://github.com/danielgross/teleprompter)) - An on-device AI for your meetings that listens to you and makes charismatic quote suggestions.
+- 🌎 [FinChat](finchat.io/) - Using AI, FinChat generates answers to questions about public companies and investors.
+- <b><code>&nbsp;10532⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;644🍴</code></b> [Petals](https://github.com/bigscience-workshop/petals)) - BitTorrent style platform for running AI models in a distributed way.
+- 🌎 [Shotstack Workflows](shotstack.io/product/workflows/) - No-code, automation workflow tool for building Generative AI media applications.
+- 🌎 [Aispect](aispect.io/?ref=mahseema-awesome-ai-tools) - New way to experience events.
+- 🌎 [PressPulse AI](www.presspulse.ai/?ref=mahseema-awesome-ai-tools) - Get personalized media coverage leads every morning.
+- 🌎 [GummySearch](gummysearch.com/?ref=mahseema-awesome-ai-tools) - AI-based customer research via Reddit. Discover problems to solve, sentiment on current solutions, and people who want to buy your product.
+- 🌎 [Taplio](taplio.com/?ref=mahseema-awesome-ai-tools) - The all-in-one, AI-powered LinkedIn tool.
+- 🌎 [PromptPal](promptpal.net) - Search for prompts and bots, then use them with your favorite AI. All in one place.
+- 🌎 [FairyTailAI](fairytailai.com/) - Personalized bedtime story generator
+- 🌎 [Myriad](www.namepepper.com/free-tools/ai-content-prompt-tool) - Scale your content creation and get the best writing from ChatGPT, Copilot, and other AIs. Build and fine-tune prompts for any kind of content, from long-form to ads and email.
+- 🌎 [GradGPT](www.gradgpt.com/) - AI tools to simplify college applications. Review applications, draft essays, find universities and requirements and more.
+- 🌎 [Code to Flow](codetoflow.com) - Visualize, Analyze, and Understand Your Code flow. Turn Code into Interactive Flowcharts with AI. Simplify Complex Logic Instantly.
+- 🌎 [AI-Flow](ai-flow.net/) - Connect multiple AI models easily.
+- 🌎 [Architecture Helper](architecturehelper.com) - Analyze any building architecture, and generate your own custom styles, in seconds.
+- 🌎 [VocalReplica](vocalreplica.com/) - AI-Powered Vocal and Instrumental Isolation for Your Favorite Tracks
+- 🌎 [AI Wedding Toast](aiweddingtoast.com) - Generate a personalized wedding speech with AI
+- 🌎 [Interviews Chat](www.interviews.chat/) - Your Personal Interview Prep & Copilot
+- 🌎 [Context Data](contextdata.ai/) - Data Processing & ETL infrastructure for Generative AI applications
+- 🌎 [ezJobs](www.getezjobs.com/) - Automated job search and applications
+- 🌎 [Compass](www.getwhys.io/compass) - AI driven answers to SaaS research questions
+- 🌎 [Adon AI](adon-web.awakast.com/en/recruiter/) - CV screening automation and blind CV generator, AI backed ATS
+- 🌎 [Persuva](persuva.ai) - Persuva is the AI-driven platform to create persuasive, high-converting ad copy at scale.
+- 🌎 [Interview Solver](interviewsolver.com) - Ace your live coding interviews with our AI Copilot
+- 🌎 [Socialsonic](socialsonic.com) - AI LinkedIn Coach: Personalized content, trends & scheduling.
+- 🌎 [Napkin](www.napkin.ai/) - Napkin turns your text into visuals so sharing your ideas is quick and effective.
+- 🌎 [Exam Samurai](www.examsamur.ai/) - AI Exam Generator
+- 🌎 [AI Watermark Remover](aiwatermarkremover.io/) - Remove watermarks from images and videos.
+- 🌎 [AISaver](aisaver.io) - Collection of AI Powered Video and Photo Tools
+- <b><code>&nbsp;&nbsp;3202⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;224🍴</code></b> [Harbor](https://github.com/av/harbor)) - run LLM backends, APIs, frontends, and services with one command
+- 🌎 [LangMagic](easytolearn.io) - Learn languages from native content.
+- 🌎 [fynk](fynk.com/) - AI powered contract management software
+- 🌎 [LooksMax AI](looksmax.ai) - Find out how hot you are using AI
+- 🌎 [Podify.io](podify.io) - Leverage AI and community to grow on LinkedIn
+- 🌎 [ResumeDive](resumedive.com) - A resume boosting service using AI
+- 🌎 [Luthor](luthor.ai/) - Programmatic content marketing at scale
+- 🌎 [Hyperbrowser](hyperbrowser.ai/) - Browser infrastructure and automation for AI Agents and Apps with advanced features like proxies, captcha solving, and session recording.
+- 🌎 [Bricks](www.thebricks.com/) - The AI Spreadsheet We've All Been Waiting For
+- 🌎 [MindStudio](mindstudio.ai/) — Build powerful AI Agents for yourself, your team, or your enterprise. Powerful, easy to use, visual builder—no coding required, but extensible with code if you need it. Over 100 templates for all kinds of business and personal use cases.
+- 🌎 [Daruy](daruy.space/) - Personalized Gift Idea Generator
+- 🌎 [Promptly](searchpromptly.com/) - Discover, create and share powerful prompts
+- 🌎 [Melies](melies.co) - AI Filmmaking software
 
 
 ## Learning resources
 
-- [Learn Prompting](https://learnprompting.org/) - A free, open-source course on communicating with artificial intelligence.
-- [Prompt Engineering Guide](https://github.com/dair-ai/Prompt-Engineering-Guide) - Guide and resources for prompt engineering.
-- [ChatGPT prompt engineering for developers](https://www.deeplearning.ai/short-courses/chatgpt-prompt-engineering-for-developers/) - A short course by Isa Fulford (OpenAI) and Andrew Ng (DeepLearning.AI).
-- [OpenAI Cookbook](https://github.com/openai/openai-cookbook) - Examples and guides for using the OpenAI API.
-- [Robert Miles AI Safety](https://www.youtube.com/@RobertMilesAI) - Youtube channel about AI safety
+- 🌎 [Learn Prompting](learnprompting.org/) - A free, open-source course on communicating with artificial intelligence.
+- <b><code>&nbsp;77964⭐</code></b> <b><code>&nbsp;&nbsp;8560🍴</code></b> [Prompt Engineering Guide](https://github.com/dair-ai/Prompt-Engineering-Guide)) - Guide and resources for prompt engineering.
+- 🌎 [ChatGPT prompt engineering for developers](www.deeplearning.ai/short-courses/chatgpt-prompt-engineering-for-developers/) - A short course by Isa Fulford (OpenAI) and Andrew Ng (DeepLearning.AI).
+- <b><code>&nbsp;75702⭐</code></b> <b><code>&nbsp;12793🍴</code></b> [OpenAI Cookbook](https://github.com/openai/openai-cookbook)) - Examples and guides for using the OpenAI API.
+- 🌎 [Robert Miles AI Safety](www.youtube.com/@RobertMilesAI) - Youtube channel about AI safety
 
 ## Learn AI free
 ### Machine Learning
-- [Roadmap](https://github.com/mrdbourke/machine-learning-roadmap) - A roadmap connecting many of the most important concepts in machine learning, how to learn them, and what tools to use to perform them.
-- [Andrew Ng’s Machine Learning at Stanford University](https://www.coursera.org/learn/machine-learning) -  Ng’s gentle introduction to machine learning course is perfect for engineers who want a foundational overview of key concepts in the field.
-- [Sebastian Thrun’s Introduction To Machine Learning](https://www.udacity.com/course/intro-to-machine-learning--ud120) - robust introduction to the subject and also the foundation for a Data Analyst “nanodegree” certification sponsored by Facebook and MongoDB.
-- [AI and Machine Learning Roadmaps](https://www.scaler.com/blog/category/artificial-intelligence-machine-learning/) - Roadmaps featuring essential concepts, learning methods, and the tools to put them into practice.
-- [How To Learn Artificial Intelligence (AI)?](https://www.appliedaicourse.com/blog/how-to-learn-artificial-intelligence-ai/) - provides a step-by-step guide for beginners to understand and develop AI skills. It covers foundational topics like programming (Python), mathematics, and machine learning, progressing to advanced concepts such as deep learning and neural networks.
+- <b><code>&nbsp;&nbsp;7892⭐</code></b> <b><code>&nbsp;&nbsp;1168🍴</code></b> [Roadmap](https://github.com/mrdbourke/machine-learning-roadmap)) - A roadmap connecting many of the most important concepts in machine learning, how to learn them, and what tools to use to perform them.
+- 🌎 [Andrew Ng’s Machine Learning at Stanford University](www.coursera.org/learn/machine-learning) -  Ng’s gentle introduction to machine learning course is perfect for engineers who want a foundational overview of key concepts in the field.
+- 🌎 [Sebastian Thrun’s Introduction To Machine Learning](www.udacity.com/course/intro-to-machine-learning--ud120) - robust introduction to the subject and also the foundation for a Data Analyst “nanodegree” certification sponsored by Facebook and MongoDB.
+- 🌎 [AI and Machine Learning Roadmaps](www.scaler.com/blog/category/artificial-intelligence-machine-learning/) - Roadmaps featuring essential concepts, learning methods, and the tools to put them into practice.
+- 🌎 [How To Learn Artificial Intelligence (AI)?](www.appliedaicourse.com/blog/how-to-learn-artificial-intelligence-ai/) - provides a step-by-step guide for beginners to understand and develop AI skills. It covers foundational topics like programming (Python), mathematics, and machine learning, progressing to advanced concepts such as deep learning and neural networks.
 
 ### Deep Learning
-- [Geoffrey Hinton’s Neural Networks For Machine Learning ](https://medium.com/kaggle-blog)- it is now removed from cousrea but still check these list
-- [Jeremy Howard’s Fast.ai & Data Institute Certificates](https://www.fast.ai/) - The in-person certificate courses are not free, but all of the content is available on Fast.ai as MOOCs.
-- [coursera-deep-learning-specialization](https://github.com/pratham5368/coursera-deep-learning-specialization) - Notes, programming assignments and quizzes from all courses within the Coursera Deep Learning specialization offered by deeplearning.ai
-- [tensorflow](https://github.com/pratham5368/Tecnologies-I-Learn/tree/main/31-pytorch) - all important notes to learn pytorch with all the examples in google colab
+- 🌎 [Geoffrey Hinton’s Neural Networks For Machine Learning ](medium.com/kaggle-blog)- it is now removed from cousrea but still check these list
+- 🌎 [Jeremy Howard’s Fast.ai & Data Institute Certificates](www.fast.ai/) - The in-person certificate courses are not free, but all of the content is available on Fast.ai as MOOCs.
+- <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0🍴</code></b> [coursera-deep-learning-specialization](https://github.com/pratham5368/coursera-deep-learning-specialization)) - Notes, programming assignments and quizzes from all courses within the Coursera Deep Learning specialization offered by deeplearning.ai
+- <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1🍴</code></b> [tensorflow](https://github.com/pratham5368/Tecnologies-I-Learn/tree/main/31-pytorch)) - all important notes to learn pytorch with all the examples in google colab
 
 ## NVIDIA Platform Extensions
 
-- [NVIDIA Omniverse AI Animal Explorer Extension](https://docs.omniverse.nvidia.com/extensions/latest/ext_animal-explorer.html#installation) - AI Animal Explorer is an Omniverse extension that enables creators to quickly prototype unique 3D animal meshes.
+- 🌎 [NVIDIA Omniverse AI Animal Explorer Extension](docs.omniverse.nvidia.com/extensions/latest/ext_animal-explorer.html#installation) - AI Animal Explorer is an Omniverse extension that enables creators to quickly prototype unique 3D animal meshes.
 
 
 ## Related Awesome Lists
 
-- [Altern](https://altern.ai) - Find Best AI Tools
-- [AI For Developers](https://aifordevelopers.org) - List of AI DevTools
-- [Best of AI](https://github.com/best-of-ai/best-of-ai) - Like Michelin Guide for AI
-- [Awesome AI Models](https://github.com/dariubs/awesome-ai-models) - A curated list of top AI models and LLMs
-- [Awesome AI Coding Tools](https://github.com/ai-for-developers/awesome-ai-coding-tools) - Curated list of AI-powered developer tools.
+- 🌎 [Altern](altern.ai) - Find Best AI Tools
+- 🌎 [AI For Developers](aifordevelopers.org) - List of AI DevTools
+- <b><code>&nbsp;&nbsp;&nbsp;702⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;115🍴</code></b> [Best of AI](https://github.com/best-of-ai/best-of-ai)) - Like Michelin Guide for AI
+- <b><code>&nbsp;&nbsp;&nbsp;147⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;18🍴</code></b> [Awesome AI Models](https://github.com/dariubs/awesome-ai-models)) - A curated list of top AI models and LLMs
+- <b><code>&nbsp;&nbsp;2044⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;633🍴</code></b> [Awesome AI Coding Tools](https://github.com/ai-for-developers/awesome-ai-coding-tools)) - Curated list of AI-powered developer tools.
 - [Awesome Vibe Coding](http://github.com/dariubs/awesome-vibe-coding) - A hand-picked collection of tools and resources for Vibe Coding.
-- [There's An AI](https://theresanai.com) - Frontpage of AI
-- [Awesome AI Books](https://github.com/mahseema/aibooks) - Curated List of Top AI and ML Books
-- [AI for Productivity](https://productivity.directory/category/ai) - Curated List of AI Apps for productivity
-- [Workflow Automation Softwares](https://productivity.directory/category/workflow-automation) - Curated List of Workflow Automation Apps And Tools
-- [Awesome Workflow Automation](https://github.com/dariubs/awesome-workflow-automation) - Curated List of Workflow Automation Apps And Tools
-- [Awesome Marketing](https://github.com/marketingtoolslist/awesome-marketing)
-- [Top AI Directories](https://github.com/best-of-ai/ai-directories) - An awesome list of best top AI directories to submit your ai tools
+- 🌎 [There's An AI](theresanai.com) - Frontpage of AI
+- <b><code>&nbsp;&nbsp;&nbsp;&nbsp;90⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;9🍴</code></b> [Awesome AI Books](https://github.com/mahseema/aibooks)) - Curated List of Top AI and ML Books
+- 🌎 [AI for Productivity](productivity.directory/category/ai) - Curated List of AI Apps for productivity
+- 🌎 [Workflow Automation Softwares](productivity.directory/category/workflow-automation) - Curated List of Workflow Automation Apps And Tools
+- <b><code>&nbsp;&nbsp;1199⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;208🍴</code></b> [Awesome Workflow Automation](https://github.com/dariubs/awesome-workflow-automation)) - Curated List of Workflow Automation Apps And Tools
+- <b><code>&nbsp;&nbsp;&nbsp;446⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;185🍴</code></b> [Awesome Marketing](https://github.com/marketingtoolslist/awesome-marketing))
+- <b><code>&nbsp;&nbsp;&nbsp;868⭐</code></b> <b><code>&nbsp;&nbsp;&nbsp;463🍴</code></b> [Top AI Directories](https://github.com/best-of-ai/ai-directories)) - An awesome list of best top AI directories to submit your ai tools
 
 
 created by [Mahsima Dastan](https://github.com/mahseema)
+
+## Source
+<b><code>&nbsp;&nbsp;6109⭐</code></b> <b><code>&nbsp;&nbsp;2114🍴</code></b> [mahseema/awesome-ai-tools](https://github.com/mahseema/awesome-ai-tools))


### PR DESCRIPTION
## Summary

- Add BulkPublish to the Marketing AI Tools section.
- Link the official product site for an AI-agent REST API and MCP server for multi-platform social publishing.

This is a self-submission; I am affiliated with BulkPublish. Canonical references:
- Skills: https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills
- API repository: https://github.com/azeemkafridi/bulkpublish-api
- MCP docs: https://app.bulkpublish.com/docs

The API/MCP integration requires credentials and can schedule or publish to connected social accounts; reviewers should keep those actions human-approved.

## Checks

- git diff --check
- Direct HTTP check of the official website passed.